### PR TITLE
feat: 로그인 및 회원가입 UI 구현

### DIFF
--- a/src/app/(beforelogin)/login/page.tsx
+++ b/src/app/(beforelogin)/login/page.tsx
@@ -1,0 +1,47 @@
+import SubmitButton from '@/app/_components/common/SubmitButton';
+import NormalInput from '@/app/_components/common/NormalInput';
+import Link from 'next/link';
+
+export default function Login() {
+  return (
+    <div className='relative inset-0 h-dvh w-dvw bg-[#FAFAFA]'>
+      <div className='absolute top-1/2 left-1/2 flex w-[392px] -translate-1/2 flex-col'>
+        <div className='mb-[10px] flex flex-col gap-[30px]'>
+          <div className='text-center text-6xl font-bold text-[#10197A]'>
+            똘개비
+          </div>
+          <form className='flex flex-col gap-[30px]'>
+            <div className='flex flex-col gap-[10px]'>
+              <div className='flex flex-col gap-[6px]'>
+                <label htmlFor='id' className='text-xl'>
+                  아이디
+                </label>
+                <NormalInput id='id' type='text' placeholder='아이디' />
+              </div>
+              <div className='flex flex-col gap-[6px]'>
+                <label htmlFor='password' className='text-xl'>
+                  비밀번호
+                </label>
+                <NormalInput
+                  id='password'
+                  type='password'
+                  placeholder='비밀번호'
+                />
+              </div>
+            </div>
+            <SubmitButton>로그인</SubmitButton>
+          </form>
+        </div>
+        <div className='text-center text-lg text-[#8E92BC]'>
+          아직 회원이 아니신가요?{' '}
+          <Link
+            href='/register'
+            className='cursor-pointer text-[#54577A] underline'
+          >
+            회원가입
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(beforelogin)/register/page.tsx
+++ b/src/app/(beforelogin)/register/page.tsx
@@ -1,0 +1,63 @@
+import SubmitButton from '@/app/_components/common/SubmitButton';
+import NormalInput from '@/app/_components/common/NormalInput';
+import Link from 'next/link';
+
+export default function Register() {
+  return (
+    <div className='relative inset-0 h-dvh w-dvw bg-[#FAFAFA]'>
+      <div className='absolute top-1/2 left-1/2 flex w-[392px] -translate-1/2 flex-col'>
+        <div className='mb-[10px] flex flex-col gap-[30px]'>
+          <div className='text-center text-6xl font-bold text-[#10197A]'>
+            회원가입
+          </div>
+          <form className='flex flex-col gap-[30px]'>
+            <div className='flex flex-col gap-[10px]'>
+              <div className='flex flex-col gap-[6px]'>
+                <label htmlFor='id' className='text-xl'>
+                  아이디
+                </label>
+                <NormalInput id='id' type='text' placeholder='아이디' />
+              </div>
+              <div className='flex flex-col gap-[6px]'>
+                <label htmlFor='nickname' className='text-xl'>
+                  닉네임
+                </label>
+                <NormalInput id='nickname' type='text' placeholder='닉네임' />
+              </div>
+              <div className='flex flex-col gap-[6px]'>
+                <label htmlFor='password' className='text-xl'>
+                  비밀번호
+                </label>
+                <NormalInput
+                  id='password'
+                  type='password'
+                  placeholder='비밀번호'
+                />
+              </div>
+              <div className='flex flex-col gap-[6px]'>
+                <label htmlFor='verifyPassword' className='text-xl'>
+                  비밀번호 확인
+                </label>
+                <NormalInput
+                  id='verifyPassword'
+                  type='password'
+                  placeholder='비밀번호'
+                />
+              </div>
+            </div>
+            <SubmitButton>회원가입</SubmitButton>
+          </form>
+        </div>
+        <div className='text-center text-lg text-[#8E92BC]'>
+          이미 아이디가 있으신가요?{' '}
+          <Link
+            href='/login'
+            className='cursor-pointer text-[#54577A] underline'
+          >
+            로그인
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/common/NormalInput.tsx
+++ b/src/app/_components/common/NormalInput.tsx
@@ -1,0 +1,19 @@
+import { ComponentPropsWithRef, ReactNode } from 'react';
+
+interface NormalInputProps extends ComponentPropsWithRef<'input'> {
+  children?: ReactNode;
+  className?: string;
+}
+
+function NormalInput({ children, className = '', ...rest }: NormalInputProps) {
+  return (
+    <div
+      className={`${className} flex gap-[16px] rounded-lg border border-[#BAC8FF] bg-[#FFFFFF] p-[16px] placeholder-[#54577A]`}
+    >
+      {children}
+      <input {...rest} className='flex-1 outline-none' />
+    </div>
+  );
+}
+
+export default NormalInput;

--- a/src/app/_components/common/SubmitButton.tsx
+++ b/src/app/_components/common/SubmitButton.tsx
@@ -1,0 +1,19 @@
+import { ComponentPropsWithRef, ReactNode } from 'react';
+
+interface ButtonProps extends ComponentPropsWithRef<'button'> {
+  children: ReactNode;
+  className?: string;
+}
+
+function SubmitButton({ children, className = '', ...rest }: ButtonProps) {
+  return (
+    <button
+      {...rest}
+      className={`${className} cursor-pointer rounded-xl bg-[#546FFF] px-[120px] py-[12px] text-[22px] font-bold text-[#FFFFFF] disabled:cursor-default disabled:opacity-40`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default SubmitButton;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 :root {
   --background: #ffffff;
@@ -23,4 +23,13 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  input:-webkit-autofill:active {
+    transition: background-color 5000s ease-in-out 0s;
+    -webkit-transition: background-color 9999s ease-out;
+    -webkit-box-shadow: 0 0 0px 1000px white inset !important;
+  }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] SubmitButton 공통 컴포넌트 생성
- [x] NormalInput 공통 컴포넌트 생성
- [x] 로그인 UI
- [x] 회원가입 UI

## 💡 자세한 설명
색상 토큰은 추후 반영해두겠습니다!

### 1️⃣ 공통 컴포넌트 : SubmitButton
로그인 및 회원가입에서 사용하는 버튼이 일정 관리 모달의 버튼, 설정 페이지의 저장 버튼과 동일하여 공통 컴포넌트로 분리해두었습니다. 사용자로부터 입력을 받고 서버로 데이터를 제출하는 용도의 버튼일 때 해당 디자인이 사용되는 것으로 판단해 `SubmitButton`이라고 이름을 지었습니다!

`ComponentPropsWithRef` 를 사용하여 `<button>` 태그의 기본 속성을 그대로 커스텀 컴포넌트도 사용할 수 있도록 했습니다.

#### 사용 예시 
```tsx
<SubmitButton>로그인</SubmitButton>

// disabled 상태일 때 
<SubmitButton disabled>로그인</SubmitButton>

// onClick 속성 사용하기 
<SubmitButton onClick={..}>로그인</SubmitButton>
```
disabled 상태의 경우 tailwind의 `disabled:` Pseudo-classes를 사용해 스타일을 변경했습니다. 
(피그마 디자인 스타일의 버튼 자료 참고-opacity 조절)

### 2️⃣ 공통 컴포넌트 : NormalInput
input의 경우도 다른 페이지에서 공통적으로 사용할 듯 싶어 생성했습니다.  border 색상을 #BAC8FF, border radius가 8px 스타일을 가지는 Input은  `NormalInput` 이란 이름으로 지었습니다! 스타일이 조금 다른 input도 존재하는데 이 Input은 따로 컴포넌트를 생성해줄지 NormalInput을 확장할지 고민이 됩니다!! 

SubmitButton 컴포넌트와 마찬가지로 `ComponentPropsWithRef`를 사용해 input 속성을 사용할 수 있도록 했습니다
input 창 내 아이콘이 들어있는 경우가 있는데 이럴 경우 children으로 해당 아이콘을 전달하도록 구현했습니다


#### 사용예시 
```tsx
<NormalInput id='id' type='text' placeholder='아이디' />

// 아이콘 넣어야할 때 
<NormalInput id='id' type='text' placeholder='아이디'>
  <Icon />
</ NormalInput>
```

### 3️⃣ 로그인 및 회원가입 UI
아직 폰트 적용이 되어 있지 않습니다! 
하단에 밑줄이 그어진 버튼은 `<Link>` 태그 사용해 서로 페이지로 이동 가능합니다.

#### 로그인 
![image](https://github.com/user-attachments/assets/2df41c2f-e8dd-4d30-9143-b6ccd7ab2362)

#### 회원가입 
![image](https://github.com/user-attachments/assets/8c715ee3-6d93-4da6-a371-73c262e305a2)


## 📗 참고 자료 (선택)
disabled 선택자 [tailwind 공식문서](https://tailwindcss.com/docs/hover-focus-and-other-states#required-and-disabled) 

## 📢 리뷰 요구 사항 (선택)



## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
