### PR TITLE
feat: 주간 캘린더 UI 구현

### DIFF
--- a/src/app/(afterlogin)/calendar/_components/CalendarContainer.tsx
+++ b/src/app/(afterlogin)/calendar/_components/CalendarContainer.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+interface CalendarContainerProps {
+  children: ReactNode;
+}
+
+function CalendarContainer({ children }: CalendarContainerProps) {
+  return (
+    <div className='bg-[#FAFAFA] px-[32px] py-[24px]'>
+      <div className='mb-[24px] flex items-center justify-between'>
+        <span className='text-[24px] font-semibold'>Todos</span>
+        <button className='bg-primary-400 hover:bg-primary-500 h-[40px] w-[40px] cursor-pointer rounded-[10px] bg-[url(/assets/plus-small.png)] bg-center bg-no-repeat'></button>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export default CalendarContainer;

--- a/src/app/(afterlogin)/calendar/_components/CalendarType.tsx
+++ b/src/app/(afterlogin)/calendar/_components/CalendarType.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { ScheduleItem } from '@/app/_types/calendar';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+function CalendarType() {
+  const pathname = usePathname();
+
+  const scheduleTypes: ScheduleItem[] = [
+    { id: 0, title: 'Day', href: '/calendar/daily' },
+    { id: 1, title: 'Week', href: '/calendar/weekly' },
+    { id: 2, title: 'Month', href: '/calendar/monthly' },
+  ];
+
+  return (
+    <div className='flex gap-[20px]'>
+      {scheduleTypes.map(type => (
+        <Link
+          href={type.href}
+          key={type.id}
+          className={`border-primary-200 cursor-pointer rounded-[10px] border-1 px-[44px] py-[8px] text-[20px] font-semibold ${pathname === type.href && 'bg-primary-400 text-primary-0'}`}
+        >
+          {type.title}
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+export default CalendarType;

--- a/src/app/(afterlogin)/calendar/_components/Progress.tsx
+++ b/src/app/(afterlogin)/calendar/_components/Progress.tsx
@@ -1,0 +1,23 @@
+import ProgressBar from '@/app/_components/tasks/ProgressBar';
+
+interface ProgressProps {
+  finishedTaskCount: number;
+  totalTaskCount: number;
+}
+
+function Progress({ finishedTaskCount, totalTaskCount }: ProgressProps) {
+  return (
+    <div className='flex max-w-[752px] items-center justify-between gap-[20px] text-[20px] font-semibold'>
+      <span className='whitespace-nowrap'>달성률</span>
+      <div className='w-full'>
+        <ProgressBar
+          finishedTaskCount={finishedTaskCount}
+          totalTaskCount={totalTaskCount}
+        />
+      </div>
+      <span className='whitespace-nowrap'>{`${finishedTaskCount} / ${totalTaskCount}`}</span>
+    </div>
+  );
+}
+
+export default Progress;

--- a/src/app/(afterlogin)/calendar/daily/page.tsx
+++ b/src/app/(afterlogin)/calendar/daily/page.tsx
@@ -2,25 +2,15 @@
 
 import BoardTitle from '@/app/_components/common/BoardTitle';
 import Navigation from '@/app/_components/nav/Navigation';
-import ProgressBar from '@/app/_components/tasks/ProgressBar';
 import TaskListItem from '@/app/_components/tasks/TaskListItem';
 import { TaskPayload } from '@/app/_types';
 import { formatTime } from '@/app/_utils';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
-
-interface ScheduleItem {
-  id: number;
-  title: string;
-}
+import CalendarType from '../_components/CalendarType';
+import Progress from '../_components/Progress';
 
 export default function Daily() {
-  const scheduleTypes: ScheduleItem[] = [
-    { id: 0, title: 'Day' },
-    { id: 1, title: 'Week' },
-    { id: 2, title: 'Month' },
-  ];
-  const [activeScheduleIndex, setActiveScheduleIndex] = useState(0);
   const [mockData, setMockData] = useState([
     {
       task_id: 1,
@@ -59,10 +49,6 @@ export default function Daily() {
   const [pendingTask, setPendingTask] = useState<TaskPayload[]>([]);
   const [finishedTaskCount, setFinishedTaskCount] = useState(0);
 
-  const handleScheduleTypeClick = (index: number) => {
-    setActiveScheduleIndex(index);
-  };
-
   const handleCheckClick = (taskId: number) => {
     setMockData(prev =>
       prev.map(task =>
@@ -84,27 +70,11 @@ export default function Daily() {
       <div className='bg-primary-0 h-full w-full min-w-[752px]'>
         <div className='flex flex-col'>
           <BoardTitle title={'오늘의 일정'}>
-            <div className='flex gap-[20px]'>
-              {scheduleTypes.map(type => (
-                <button
-                  key={type.id}
-                  className={`border-primary-200 cursor-pointer rounded-[10px] border-1 px-[44px] py-[8px] text-[20px] font-semibold ${activeScheduleIndex === type.id && 'bg-primary-400 text-primary-0'}`}
-                  onClick={() => handleScheduleTypeClick(type.id)}
-                >
-                  {type.title}
-                </button>
-              ))}
-            </div>
-            <div className='flex max-w-[752px] items-center justify-between gap-[20px] text-[20px] font-semibold'>
-              <span className='whitespace-nowrap'>달성률</span>
-              <div className='w-full'>
-                <ProgressBar
-                  finishedTaskCount={finishedTaskCount}
-                  totalTaskCount={mockData.length}
-                />
-              </div>
-              <span className='whitespace-nowrap'>{`${finishedTaskCount} / ${mockData.length}`}</span>
-            </div>
+            <CalendarType />
+            <Progress
+              finishedTaskCount={finishedTaskCount}
+              totalTaskCount={mockData.length}
+            />
           </BoardTitle>
           <div className='flex h-full justify-between bg-[#FAFAFA] px-[32px] py-[24px]'>
             <div className='mr-[34px] min-w-[752px]'>

--- a/src/app/(afterlogin)/calendar/monthly/monthlyCalendar.css
+++ b/src/app/(afterlogin)/calendar/monthly/monthlyCalendar.css
@@ -55,7 +55,7 @@
   width: 18px;
 }
 
-.rbc-row:nth-child(3n + 2) {
+.rbc-month-view .rbc-row:nth-child(3n + 2) {
   .rbc-event {
     background-color: var(--primary-900);
     color: var(--primary-900);
@@ -79,7 +79,7 @@
   }
 }
 
-.rbc-row:nth-child(3n + 3) {
+.rbc-month-view .rbc-row:nth-child(3n + 3) {
   .rbc-event {
     background-color: var(--success-900);
     color: var(--success-900);
@@ -103,7 +103,7 @@
   }
 }
 
-.rbc-row:nth-child(3n + 1) {
+.rbc-month-view .rbc-row:nth-child(3n + 1) {
   .rbc-event {
     background-color: var(--error-900);
     color: var(--error-900);

--- a/src/app/(afterlogin)/calendar/monthly/page.tsx
+++ b/src/app/(afterlogin)/calendar/monthly/page.tsx
@@ -2,26 +2,17 @@
 
 import BoardTitle from '@/app/_components/common/BoardTitle';
 import Navigation from '@/app/_components/nav/Navigation';
-import ProgressBar from '@/app/_components/tasks/ProgressBar';
 import { ko } from 'date-fns/locale';
 import { format, getDay, parse, startOfWeek } from 'date-fns';
 import { useEffect, useState } from 'react';
 import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
-import '../calendar.css';
+import './monthlyCalendar.css';
 import { TaskCalendar } from '@/app/_types';
-
-interface ScheduleItem {
-  id: number;
-  title: string;
-}
+import CalendarType from '../_components/CalendarType';
+import Progress from '../_components/Progress';
+import CalendarContainer from '../_components/CalendarContainer';
 
 export default function Monthly() {
-  const scheduleTypes: ScheduleItem[] = [
-    { id: 0, title: 'Day' },
-    { id: 1, title: 'Week' },
-    { id: 2, title: 'Month' },
-  ];
-  const [activeScheduleIndex, setActiveScheduleIndex] = useState(0);
   const [mockData] = useState([
     {
       task_id: 1,
@@ -68,10 +59,6 @@ export default function Monthly() {
     locales: { ko },
   });
 
-  const handleScheduleTypeClick = (index: number) => {
-    setActiveScheduleIndex(index);
-  };
-
   useEffect(() => {
     if (mockData && mockData.length > 0) {
       const formattedData = mockData.map(task => ({
@@ -92,33 +79,13 @@ export default function Monthly() {
       <div className='bg-primary-0 h-full w-full min-w-[752px]'>
         <div className='flex flex-col'>
           <BoardTitle title='일정 관리'>
-            <div className='flex gap-[20px]'>
-              {scheduleTypes.map(type => (
-                <button
-                  key={type.id}
-                  className={`border-primary-200 cursor-pointer rounded-[10px] border-1 px-[44px] py-[8px] text-[20px] font-semibold ${activeScheduleIndex === type.id && 'bg-primary-400 text-primary-0'}`}
-                  onClick={() => handleScheduleTypeClick(type.id)}
-                >
-                  {type.title}
-                </button>
-              ))}
-            </div>
-            <div className='flex max-w-[752px] items-center justify-between gap-[20px] text-[20px] font-semibold'>
-              <span className='whitespace-nowrap'>달성률</span>
-              <div className='w-full'>
-                <ProgressBar
-                  finishedTaskCount={finishedTaskCount}
-                  totalTaskCount={mockData.length}
-                />
-              </div>
-              <span className='whitespace-nowrap'>{`${finishedTaskCount} / ${mockData.length}`}</span>
-            </div>
+            <CalendarType />
+            <Progress
+              finishedTaskCount={finishedTaskCount}
+              totalTaskCount={mockData.length}
+            />
           </BoardTitle>
-          <div className='bg-[#FAFAFA] px-[32px] py-[24px]'>
-            <div className='mb-[24px] flex items-center justify-between'>
-              <span className='text-[24px] font-semibold'>Todos</span>
-              <button className='bg-primary-400 hover:bg-primary-500 h-[40px] w-[40px] cursor-pointer rounded-[10px] bg-[url(/assets/plus-small.png)] bg-center bg-no-repeat'></button>
-            </div>
+          <CalendarContainer>
             <div className='h-[937px]'>
               <Calendar
                 localizer={localizer}
@@ -130,7 +97,7 @@ export default function Monthly() {
                 views={['month']}
               ></Calendar>
             </div>
-          </div>
+          </CalendarContainer>
         </div>
       </div>
     </div>

--- a/src/app/(afterlogin)/calendar/weekly/CustomWeekEvent.tsx
+++ b/src/app/(afterlogin)/calendar/weekly/CustomWeekEvent.tsx
@@ -1,0 +1,19 @@
+import { TaskCalendarAllDay } from '@/app/_types';
+import { format } from 'date-fns';
+
+interface CustomWeekEventProps {
+  event: TaskCalendarAllDay;
+}
+
+function CustomWeekEvent({ event }: CustomWeekEventProps) {
+  return (
+    <div className='flex flex-col gap-[2px] p-[4px]'>
+      <div className='text-[12px] font-semibold'>{event.title}</div>
+      {!event.allDay && (
+        <div className='text-[8px] font-normal'>{`${format(event.start_time, 'h:mma')} - ${format(event.end_time, 'h:mma')}`}</div>
+      )}
+    </div>
+  );
+}
+
+export default CustomWeekEvent;

--- a/src/app/(afterlogin)/calendar/weekly/page.tsx
+++ b/src/app/(afterlogin)/calendar/weekly/page.tsx
@@ -40,7 +40,6 @@ export default function Weekly() {
       place_name: 'Zep 4번 룸',
       location: { lat: '127.1086228', lng: '37.4012191' },
       is_completed: false,
-      allDay: true,
     },
     {
       task_id: 3,

--- a/src/app/(afterlogin)/calendar/weekly/page.tsx
+++ b/src/app/(afterlogin)/calendar/weekly/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import Navigation from '@/app/_components/nav/Navigation';
+import { format } from 'date-fns/format';
+import { parse } from 'date-fns/parse';
+import { startOfWeek } from 'date-fns/startOfWeek';
+import { getDay } from 'date-fns/getDay';
+import { ko } from 'date-fns/locale';
+import './weeklyCalendar.css';
+import { Calendar, dateFnsLocalizer, DateLocalizer } from 'react-big-calendar';
+import { useMemo, useState } from 'react';
+import BoardTitle from '@/app/_components/common/BoardTitle';
+import { isEqual } from 'date-fns';
+import CustomWeekEvent from './CustomWeekEvent';
+import { Formats } from 'react-big-calendar';
+import CalendarType from '../_components/CalendarType';
+import Progress from '../_components/Progress';
+import CalendarContainer from '../_components/CalendarContainer';
+
+export default function Weekly() {
+  const [mockData] = useState([
+    {
+      task_id: 1,
+      title: '일어나기',
+      memo: '',
+      start_time: '2025-04-07T08:00:00',
+      end_time: '2025-04-07T10:00:00',
+      address: '경기도 수원시 ...',
+      place_name: 'Cafe ABC',
+      location: { lat: '', lng: '' },
+      is_completed: true,
+    },
+    {
+      task_id: 2,
+      title: 'Team meeting',
+      memo: '주간 회의',
+      start_time: '2025-04-11T15:00:00',
+      end_time: '',
+      address: '경기도 수원시 ...',
+      place_name: 'Zep 4번 룸',
+      location: { lat: '127.1086228', lng: '37.4012191' },
+      is_completed: false,
+      allDay: true,
+    },
+    {
+      task_id: 3,
+      title: '구현하기',
+      memo: '수요일까지 구현해요',
+      start_time: '2025-04-11T13:00:00',
+      end_time: '2025-04-13T14:00:00',
+      address: '경기도 수원시 ...',
+      place_name: 'Cafe DEF',
+      location: { lat: '127.1086228', lng: '37.4012191' },
+      is_completed: false,
+    },
+  ]);
+  const finishedTaskCount = mockData
+    ? mockData.filter(task => task.is_completed).length
+    : 0;
+
+  const { formats, components, events, localizer } = useMemo(
+    () => ({
+      events: mockData.map(task => {
+        const start = new Date(task.start_time);
+        const end = new Date(task.end_time || task.start_time);
+
+        return {
+          ...task,
+          start_time: start,
+          end_time: end,
+          allDay: isEqual(start, end) ? true : false,
+        };
+      }),
+      localizer: dateFnsLocalizer({
+        format,
+        parse,
+        startOfWeek,
+        getDay,
+        locales: { ko },
+      }),
+      formats: {
+        timeGutterFormat: (
+          date: Date,
+          culture: string,
+          localizer: DateLocalizer,
+        ) => localizer.format(date, 'haa', culture),
+        dayFormat: (date: Date, culture: string, localizer: DateLocalizer) =>
+          localizer.format(date, 'eee dd', culture),
+      } as Formats,
+      components: {
+        week: {
+          event: CustomWeekEvent,
+        },
+      },
+    }),
+    [mockData],
+  );
+
+  return (
+    <div className='text-secondary-500 inline-flex h-full min-h-screen w-full bg-[#FAFAFA]'>
+      <Navigation />
+      <div className='bg-primary-0 h-full w-full min-w-[752px]'>
+        <div className='flex flex-col'>
+          <BoardTitle title='일정 관리'>
+            <CalendarType />
+            <Progress
+              finishedTaskCount={finishedTaskCount}
+              totalTaskCount={mockData.length}
+            />
+          </BoardTitle>
+          <CalendarContainer>
+            <Calendar
+              localizer={localizer}
+              events={events}
+              defaultView='week'
+              views={['week']}
+              startAccessor='start_time'
+              endAccessor='end_time'
+              toolbar={false}
+              formats={formats}
+              components={components}
+            />
+          </CalendarContainer>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(afterlogin)/calendar/weekly/weeklyCalendar.css
+++ b/src/app/(afterlogin)/calendar/weekly/weeklyCalendar.css
@@ -1,132 +1,137 @@
 @import 'react-big-calendar/lib/css/react-big-calendar.css';
 
-/* 기본 스타일 초기화 */
-.rbc-time-view,
-.rbc-time-header-content,
-.rbc-header,
-.rbc-time-header.rbc-overflowing,
-.rbc-time-header,
-.rbc-time-content,
-.rbc-timeslot-group,
-.rbc-time-content > * + * > *,
-.rbc-day-slot .rbc-time-slot {
-  border: none;
-}
+.rbc-time-view {
+  /* 기본 스타일 초기화 */
+  border: none !important;
 
-.rbc-today {
-  background: none;
-}
-
-.rbc-day-slot .rbc-events-container {
-  margin-right: 0;
-}
-
-.rbc-event-label {
-  display: none;
-}
-
-/* border 스타일 */
-.rbc-header + .rbc-header {
-  border-left: 1px solid var(--primary-0);
-}
-
-.rbc-day-bg + .rbc-day-bg,
-.rbc-events-container,
-.rbc-row-bg {
-  border-left: 1px solid var(--primary-100);
-}
-
-.rbc-row-bg,
-.rbc-time-gutter {
-  border-right: 1px solid var(--primary-100);
-}
-
-.rbc-day-slot .rbc-timeslot-group {
-  border-top: 1px solid var(--primary-100);
-}
-
-/* 배경색 스타일 */
-.rbc-day-bg:first-child,
-.rbc-day-bg:last-child,
-.rbc-time-content .rbc-day-slot:nth-child(2),
-.rbc-time-content .rbc-day-slot:nth-child(8) {
-  background-color: rgba(220, 228, 255, 0.5);
-}
-
-.rbc-day-slot,
-.rbc-day-bg {
-  background-color: var(--primary-0);
-}
-
-.rbc-event {
-  background-color: var(--primary-600);
-}
-
-/* 주간 헤더 스타일 */
-.rbc-time-view .rbc-row {
-  height: 60px;
-}
-
-.rbc-time-view .rbc-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: var(--primary-300);
-  padding: 10px 8px 10px 8px;
-  span {
-    font-size: 14px;
-    font-weight: 700;
+  .rbc-time-header-content,
+  .rbc-header,
+  .rbc-time-header.rbc-overflowing,
+  .rbc-time-header,
+  .rbc-time-content,
+  .rbc-timeslot-group,
+  .rbc-time-content > * + * > *,
+  .rbc-day-slot .rbc-time-slot {
+    border: none;
   }
-}
 
-.rbc-header.rbc-today {
-  background-color: var(--primary-600);
-}
+  .rbc-today,
+  .rbc-event,
+  .rbc-day-slot .rbc-background-event {
+    background: none;
+  }
 
-.rbc-time-header-content {
-  color: var(--primary-0);
-  border-radius: 10px 10px 0px 0px;
-}
+  .rbc-day-slot .rbc-events-container {
+    margin-right: 0;
+  }
 
-.rbc-row > .rbc-header:first-child {
-  border-top-left-radius: 10px;
-}
+  .rbc-event-label {
+    display: none;
+  }
 
-.rbc-row > .rbc-header:last-child {
-  border-top-right-radius: 10px;
-}
+  /* border 스타일 */
+  .rbc-header + .rbc-header {
+    border-left: 1px solid var(--primary-0);
+  }
 
-/* 주간 이벤트 스타일 */
-.rbc-label {
-  font-size: 8px;
-  font-weight: 700;
-  color: var(--secondary-400);
-}
+  .rbc-day-bg + .rbc-day-bg,
+  .rbc-events-container,
+  .rbc-row-bg {
+    border-left: 1px solid var(--primary-100);
+  }
 
-.rbc-day-slot .rbc-event {
-  background-color: var(--primary-100);
-  border: none;
-  padding: 0px;
-  border-radius: 4px;
-  color: var(--primary-900);
-}
+  .rbc-row-bg,
+  .rbc-time-gutter {
+    border-right: 1px solid var(--primary-100);
+  }
 
-.rbc-day-slot .rbc-event:before {
-  content: '';
-  background-color: var(--primary-600);
-  width: 3px;
-  height: 100%;
-}
+  .rbc-day-slot .rbc-timeslot-group {
+    border-top: 1px solid var(--primary-100);
+  }
 
-.rbc-event.rbc-selected,
-.rbc-day-slot.rbc-selected.rbc-background-event {
-  background-color: var(--primary-700);
-  color: var(--primary-0);
-}
-.rbc-event-continues-prior,
-.rbc-event.rbc-selected.rbc-event-allday.rbc-event-continues-prior {
-  background-color: var(--primary-100);
-  .rbc-event-content {
-    padding: 2px 2px 2px 3px;
+  /* 배경색 스타일 */
+  .rbc-day-bg:first-child,
+  .rbc-day-bg:last-child,
+  .rbc-time-content .rbc-day-slot:nth-child(2),
+  .rbc-time-content .rbc-day-slot:nth-child(8) {
+    background-color: rgba(220, 228, 255, 0.5);
+  }
+
+  .rbc-day-slot,
+  .rbc-day-bg {
+    background-color: var(--primary-0);
+  }
+
+  .rbc-event {
+    background-color: var(--primary-600);
+  }
+
+  /* 주간 헤더 스타일 */
+  .rbc-row {
+    height: 60px;
+  }
+
+  .rbc-header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--primary-300);
+    padding: 10px 8px 10px 8px;
+    span {
+      font-size: 14px;
+      font-weight: 700;
+    }
+  }
+
+  .rbc-header.rbc-today {
+    background-color: var(--primary-600);
+  }
+
+  .rbc-time-header-content {
+    color: var(--primary-0);
+    border-radius: 10px 10px 0px 0px;
+  }
+
+  .rbc-row > .rbc-header:first-child {
+    border-top-left-radius: 10px;
+  }
+
+  .rbc-row > .rbc-header:last-child {
+    border-top-right-radius: 10px;
+  }
+
+  /* 주간 이벤트 스타일 */
+  .rbc-label {
+    font-size: 8px;
+    font-weight: 700;
+    color: var(--secondary-400);
+  }
+
+  .rbc-day-slot .rbc-event {
+    background-color: var(--primary-100);
+    border: none;
+    padding: 0px;
+    border-radius: 4px;
+    color: var(--primary-900);
+  }
+
+  .rbc-day-slot .rbc-event:before {
+    content: '';
+    background-color: var(--primary-600);
+    width: 3px;
+    height: 100%;
+  }
+
+  .rbc-event.rbc-selected,
+  .rbc-day-slot.rbc-selected.rbc-background-event {
+    background-color: var(--primary-700);
+    color: var(--primary-0);
+  }
+  .rbc-event-continues-prior,
+  .rbc-event.rbc-selected.rbc-event-allday.rbc-event-continues-prior {
+    background-color: var(--primary-100);
+    .rbc-event-content {
+      padding: 2px 2px 2px 3px;
+    }
   }
 }

--- a/src/app/(afterlogin)/calendar/weekly/weeklyCalendar.css
+++ b/src/app/(afterlogin)/calendar/weekly/weeklyCalendar.css
@@ -1,0 +1,132 @@
+@import 'react-big-calendar/lib/css/react-big-calendar.css';
+
+/* 기본 스타일 초기화 */
+.rbc-time-view,
+.rbc-time-header-content,
+.rbc-header,
+.rbc-time-header.rbc-overflowing,
+.rbc-time-header,
+.rbc-time-content,
+.rbc-timeslot-group,
+.rbc-time-content > * + * > *,
+.rbc-day-slot .rbc-time-slot {
+  border: none;
+}
+
+.rbc-today {
+  background: none;
+}
+
+.rbc-day-slot .rbc-events-container {
+  margin-right: 0;
+}
+
+.rbc-event-label {
+  display: none;
+}
+
+/* border 스타일 */
+.rbc-header + .rbc-header {
+  border-left: 1px solid var(--primary-0);
+}
+
+.rbc-day-bg + .rbc-day-bg,
+.rbc-events-container,
+.rbc-row-bg {
+  border-left: 1px solid var(--primary-100);
+}
+
+.rbc-row-bg,
+.rbc-time-gutter {
+  border-right: 1px solid var(--primary-100);
+}
+
+.rbc-day-slot .rbc-timeslot-group {
+  border-top: 1px solid var(--primary-100);
+}
+
+/* 배경색 스타일 */
+.rbc-day-bg:first-child,
+.rbc-day-bg:last-child,
+.rbc-time-content .rbc-day-slot:nth-child(2),
+.rbc-time-content .rbc-day-slot:nth-child(8) {
+  background-color: rgba(220, 228, 255, 0.5);
+}
+
+.rbc-day-slot,
+.rbc-day-bg {
+  background-color: var(--primary-0);
+}
+
+.rbc-event {
+  background-color: var(--primary-600);
+}
+
+/* 주간 헤더 스타일 */
+.rbc-time-view .rbc-row {
+  height: 60px;
+}
+
+.rbc-time-view .rbc-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--primary-300);
+  padding: 10px 8px 10px 8px;
+  span {
+    font-size: 14px;
+    font-weight: 700;
+  }
+}
+
+.rbc-header.rbc-today {
+  background-color: var(--primary-600);
+}
+
+.rbc-time-header-content {
+  color: var(--primary-0);
+  border-radius: 10px 10px 0px 0px;
+}
+
+.rbc-row > .rbc-header:first-child {
+  border-top-left-radius: 10px;
+}
+
+.rbc-row > .rbc-header:last-child {
+  border-top-right-radius: 10px;
+}
+
+/* 주간 이벤트 스타일 */
+.rbc-label {
+  font-size: 8px;
+  font-weight: 700;
+  color: var(--secondary-400);
+}
+
+.rbc-day-slot .rbc-event {
+  background-color: var(--primary-100);
+  border: none;
+  padding: 0px;
+  border-radius: 4px;
+  color: var(--primary-900);
+}
+
+.rbc-day-slot .rbc-event:before {
+  content: '';
+  background-color: var(--primary-600);
+  width: 3px;
+  height: 100%;
+}
+
+.rbc-event.rbc-selected,
+.rbc-day-slot.rbc-selected.rbc-background-event {
+  background-color: var(--primary-700);
+  color: var(--primary-0);
+}
+.rbc-event-continues-prior,
+.rbc-event.rbc-selected.rbc-event-allday.rbc-event-continues-prior {
+  background-color: var(--primary-100);
+  .rbc-event-content {
+    padding: 2px 2px 2px 3px;
+  }
+}

--- a/src/app/_types/calendar.ts
+++ b/src/app/_types/calendar.ts
@@ -1,0 +1,5 @@
+export interface ScheduleItem {
+  id: number;
+  title: string;
+  href: string;
+}

--- a/src/app/_types/index.ts
+++ b/src/app/_types/index.ts
@@ -17,3 +17,7 @@ export interface TaskCalendar extends Task {
   start_time: Date;
   end_time: Date;
 }
+
+export interface TaskCalendarAllDay extends TaskCalendar {
+  allDay?: boolean;
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] 주간 캘린더 UI 구현 
- [x] 스케줄 타입 버튼 및 달성률 컴포넌트 이용하여 주간 일정 페이지 UI 구현

## 💡 자세한 설명

### 1️⃣ 스타일 파일 
css 파일은 주간과 월간 캘린더 사이에 공통점을 찾으며 구현하기 어려워 주간 캘린더용 스타일 파일을 생성했습니다. 


### 2️⃣ 캘린더 구현 설명
```ts
const { formats, components, events, localizer } = useMemo(
    () => ({
      events: mockData.map(task => { ... }),
      localizer: ...
      formats: {
        timeGutterFormat: ( ... ) => ..,
        dayFormat: ( ... ) => ..,
      components: {...},
    }),
    [mockData],
  );

```
`<Calendar>` 로 전달되는 prop이 객체, 배열, 날짜, 함수이거나 복잡한 변수타입일 경우 메모이제이션을 권장하여 useMemo를 사용해 메모이제이션 해주었습니다. 추가로 `CustomWeekEvent` 컴포넌트는 캘린더의 event를 커스텀한 컴포넌트입니다! Calendar의 components prop에 사용됩니다.

### 3️⃣ 일정 페이지의 공통 컴포넌트

일정 페이지마다 공통적으로 들어가는 코드는 공통 컴포넌트로 빼두는게 좋을 것 같아서 생성 후 주간 페이지에만 일단 적용시켜두었습니다! 지혜님 의견 반영하여 수정하고 반영하거나 복구시킬 예정입니다! 
공통으로 분리된 컴포넌트는 아래와 같습니다

- `<CalendarType />`
- `<Progress />`
- `<CalendarContainer />`

아직 버튼을 클릭했을 경우 페이지 이동 기능은 없지만 next.js의 usePathname 훅을 사용하여 pathname을 비교하면 어떨까싶습니다. 한번 테스트는 해보았는데 제 컴퓨터가 성능이 안좋아서인지는 모르겠지만 페이지 이동이 느렸습니다. ( PR 작성하면서도 타이핑이 늦는걸 보면 제 컴퓨터 이슈일 가능성이 높습니닷..)

#### 스크린샷(gif)
![2025-04-07 22;05;39](https://github.com/user-attachments/assets/fe74dc59-f26b-4721-a137-8ff587274025)


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
