### PR TITLE
feat: 일정 추가, 수정, 상세보기 모달과 페이지 연결

### DIFF
--- a/src/app/(afterlogin)/calendar/_components/CalendarContainer.tsx
+++ b/src/app/(afterlogin)/calendar/_components/CalendarContainer.tsx
@@ -1,18 +1,29 @@
-import { ReactNode } from 'react';
+import TaskModal from '@/app/_components/tasks/TaskModal';
+import { ReactNode, useState } from 'react';
 
 interface CalendarContainerProps {
   children: ReactNode;
 }
 
 function CalendarContainer({ children }: CalendarContainerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const addTask = () => setIsOpen(true);
+
   return (
-    <div className='bg-[#FAFAFA] px-[32px] py-[24px]'>
-      <div className='mb-[24px] flex items-center justify-between'>
-        <span className='text-[24px] font-semibold'>Todos</span>
-        <button className='bg-primary-400 hover:bg-primary-500 h-[40px] w-[40px] cursor-pointer rounded-[10px] bg-[url(/assets/plus-small.png)] bg-center bg-no-repeat'></button>
+    <>
+      <div className='bg-[#FAFAFA] px-[32px] py-[24px]'>
+        <div className='mb-[24px] flex items-center justify-between'>
+          <span className='text-[24px] font-semibold'>Todos</span>
+          <button
+            onClick={addTask}
+            className='bg-primary-400 hover:bg-primary-500 h-[40px] w-[40px] cursor-pointer rounded-[10px] bg-[url(/assets/plus-small.png)] bg-center bg-no-repeat'
+          ></button>
+        </div>
+        {children}
       </div>
-      {children}
-    </div>
+      <TaskModal mode='add' isOpen={isOpen} setIsOpen={setIsOpen} task={null} />
+    </>
   );
 }
 

--- a/src/app/(afterlogin)/calendar/daily/page.tsx
+++ b/src/app/(afterlogin)/calendar/daily/page.tsx
@@ -9,8 +9,10 @@ import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import CalendarType from '../_components/CalendarType';
 import Progress from '../_components/Progress';
+import TaskModal from '@/app/_components/tasks/TaskModal';
 
 export default function Daily() {
+  const [isOpen, setIsOpen] = useState(false);
   const [mockData, setMockData] = useState([
     {
       task_id: 1,
@@ -59,6 +61,8 @@ export default function Daily() {
     );
   };
 
+  const addTask = () => setIsOpen(true);
+
   useEffect(() => {
     setFinishedTaskCount(mockData.filter(task => task.is_completed).length);
     setPendingTask(mockData.filter(task => !task.is_completed));
@@ -80,7 +84,10 @@ export default function Daily() {
             <div className='mr-[34px] min-w-[752px]'>
               <div className='mb-[18px] flex justify-between'>
                 <span className='text-[24px] font-semibold'>Todos</span>
-                <button className='bg-primary-400 hover:bg-primary-500 h-[40px] w-[40px] cursor-pointer rounded-[10px] bg-[url(/assets/plus-small.png)] bg-center bg-no-repeat'></button>
+                <button
+                  onClick={addTask}
+                  className='bg-primary-400 hover:bg-primary-500 h-[40px] w-[40px] cursor-pointer rounded-[10px] bg-[url(/assets/plus-small.png)] bg-center bg-no-repeat'
+                ></button>
               </div>
               <ul className='flex flex-col gap-y-[10px]'>
                 {mockData.map((task, index) => {
@@ -148,6 +155,7 @@ export default function Daily() {
           </div>
         </div>
       </div>
+      <TaskModal mode='add' isOpen={isOpen} setIsOpen={setIsOpen} task={null} />
     </div>
   );
 }

--- a/src/app/(afterlogin)/calendar/monthly/page.tsx
+++ b/src/app/(afterlogin)/calendar/monthly/page.tsx
@@ -4,15 +4,18 @@ import BoardTitle from '@/app/_components/common/BoardTitle';
 import Navigation from '@/app/_components/nav/Navigation';
 import { ko } from 'date-fns/locale';
 import { format, getDay, parse, startOfWeek } from 'date-fns';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
 import './monthlyCalendar.css';
 import { TaskCalendar } from '@/app/_types';
 import CalendarType from '../_components/CalendarType';
 import Progress from '../_components/Progress';
 import CalendarContainer from '../_components/CalendarContainer';
+import TaskModal from '@/app/_components/tasks/TaskModal';
 
 export default function Monthly() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectEvent, setSelectEvent] = useState<TaskCalendar | null>(null);
   const [mockData] = useState([
     {
       task_id: 1,
@@ -59,6 +62,11 @@ export default function Monthly() {
     locales: { ko },
   });
 
+  const onSelectEvent = useCallback((event: TaskCalendar) => {
+    setIsOpen(true);
+    setSelectEvent(event);
+  }, []);
+
   useEffect(() => {
     if (mockData && mockData.length > 0) {
       const formattedData = mockData.map(task => ({
@@ -95,11 +103,18 @@ export default function Monthly() {
                 toolbar={false}
                 events={calendarMockData}
                 views={['month']}
+                onSelectEvent={onSelectEvent}
               ></Calendar>
             </div>
           </CalendarContainer>
         </div>
       </div>
+      <TaskModal
+        mode='detail'
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        task={selectEvent}
+      />
     </div>
   );
 }

--- a/src/app/(afterlogin)/calendar/weekly/page.tsx
+++ b/src/app/(afterlogin)/calendar/weekly/page.tsx
@@ -8,7 +8,7 @@ import { getDay } from 'date-fns/getDay';
 import { ko } from 'date-fns/locale';
 import './weeklyCalendar.css';
 import { Calendar, dateFnsLocalizer, DateLocalizer } from 'react-big-calendar';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import BoardTitle from '@/app/_components/common/BoardTitle';
 import { isEqual } from 'date-fns';
 import CustomWeekEvent from './CustomWeekEvent';
@@ -16,9 +16,13 @@ import { Formats } from 'react-big-calendar';
 import CalendarType from '../_components/CalendarType';
 import Progress from '../_components/Progress';
 import CalendarContainer from '../_components/CalendarContainer';
+import { TaskCalendar, TaskPayload } from '@/app/_types';
+import TaskModal from '@/app/_components/tasks/TaskModal';
 
 export default function Weekly() {
-  const [mockData] = useState([
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectEvent, setSelectEvent] = useState<TaskCalendar | null>(null);
+  const [mockData] = useState<TaskPayload[]>([
     {
       task_id: 1,
       title: '일어나기',
@@ -95,6 +99,11 @@ export default function Weekly() {
     [mockData],
   );
 
+  const onSelectEvent = useCallback((event: TaskCalendar) => {
+    setIsOpen(true);
+    setSelectEvent(event);
+  }, []);
+
   return (
     <div className='text-secondary-500 inline-flex h-full min-h-screen w-full bg-[#FAFAFA]'>
       <Navigation />
@@ -118,10 +127,17 @@ export default function Weekly() {
               toolbar={false}
               formats={formats}
               components={components}
+              onSelectEvent={onSelectEvent}
             />
           </CalendarContainer>
         </div>
       </div>
+      <TaskModal
+        mode='detail'
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        task={selectEvent}
+      />
     </div>
   );
 }

--- a/src/app/_components/tasks/DayPickerModal.tsx
+++ b/src/app/_components/tasks/DayPickerModal.tsx
@@ -87,7 +87,7 @@ function DayPickerModal({
   return (
     <div
       ref={pickerRef}
-      className='bg-primary-0 absolute mt-[46px] flex flex-col gap-[30px] rounded-[10px] p-2.5 shadow-lg'
+      className='bg-primary-0 absolute mt-[46px] flex flex-col gap-[10px] rounded-[10px] p-2.5 shadow-lg'
     >
       <DayPicker
         animate

--- a/src/app/_components/tasks/TaskListItem.tsx
+++ b/src/app/_components/tasks/TaskListItem.tsx
@@ -1,92 +1,102 @@
 import { formatTime } from '@/app/_utils';
 import Image from 'next/image';
+import TaskModal from './TaskModal';
+import { useState } from 'react';
+import { TaskPayload } from '@/app/_types';
 
 interface TaskProps {
-  task: {
-    task_id: number;
-    title: string;
-    memo?: string;
-    start_time: string;
-    end_time?: string;
-    address?: string;
-    place_name?: string;
-    location?: { lat: string; lng: string };
-    is_completed: boolean;
-  };
+  task: TaskPayload;
   index: number;
   handleCheckClick: (taskId: number) => void;
 }
 
 function TaskListItem({ task, index, handleCheckClick }: TaskProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const editTask = () => {
+    setIsOpen(true);
+  };
+
   return (
-    <li className='flex' key={index}>
-      <div
-        className={`bg-primary-0 flex min-h-[76px] w-full items-center rounded-l-[10px] border-1 px-[23px] py-[18px] ${task.is_completed ? 'bg-primary-400 border-primary-300' : 'bg-primary-0 border-primary-100'}`}
-      >
-        <div className='flex w-full items-start'>
-          <input
-            type='checkbox'
-            checked={task.is_completed}
-            onChange={() => handleCheckClick(task.task_id)}
-            className={
-              'bg-primary-200 checked:bg-primary-0 h-[30px] w-[30px] cursor-pointer appearance-none rounded-[10px] bg-[auto_26px] checked:bg-[url(/assets/check.png)] checked:bg-center checked:bg-no-repeat'
-            }
-          />
-          <div
-            className={`flex w-full justify-between ${task.is_completed ? 'text-primary-100' : 'text-secondary-500'}`}
-          >
+    <>
+      <li className='flex' key={index}>
+        <div
+          className={`bg-primary-0 flex min-h-[76px] w-full items-center rounded-l-[10px] border-1 px-[23px] py-[18px] ${task.is_completed ? 'bg-primary-400 border-primary-300' : 'bg-primary-0 border-primary-100'}`}
+        >
+          <div className='flex w-full items-start'>
+            <input
+              type='checkbox'
+              checked={task.is_completed}
+              onChange={() => handleCheckClick(task.task_id)}
+              className={
+                'bg-primary-200 checked:bg-primary-0 h-[30px] w-[30px] cursor-pointer appearance-none rounded-[10px] bg-[auto_26px] checked:bg-[url(/assets/check.png)] checked:bg-center checked:bg-no-repeat'
+              }
+            />
             <div
-              className={`ml-[19px] text-[20px] font-semibold ${task.is_completed && 'line-through'}`}
+              className={`flex w-full justify-between ${task.is_completed ? 'text-primary-100' : 'text-secondary-500'}`}
             >
-              <span>{task.title}</span>
-              {task.location && (
-                <div className='mt-[10px] mb-[10px] flex text-[16px] font-medium'>
-                  <div className='mr-[5px] h-[20px] w-[20px]'>
-                    <Image
-                      src={`${task.is_completed ? '/assets/location-light.png' : '/assets/location.png'}`}
-                      width={20}
-                      height={20}
-                      alt='location icon'
-                    />
+              <div
+                className={`ml-[19px] text-[20px] font-semibold ${task.is_completed && 'line-through'}`}
+              >
+                <span>{task.title}</span>
+                {task.location && (
+                  <div className='mt-[10px] mb-[10px] flex text-[16px] font-medium'>
+                    <div className='mr-[5px] h-[20px] w-[20px]'>
+                      <Image
+                        src={`${task.is_completed ? '/assets/location-light.png' : '/assets/location.png'}`}
+                        width={20}
+                        height={20}
+                        alt='location icon'
+                      />
+                    </div>
+                    {task.place_name}
                   </div>
-                  {task.place_name}
-                </div>
-              )}
-              {task.memo && (
-                <ul className='flex list-disc flex-col gap-y-[6px] text-[16px] font-medium'>
-                  <li className='ml-[20px]'>{task.memo}</li>
-                </ul>
-              )}
-            </div>
-            <div className='text-right text-[20px] font-medium'>
-              {task.start_time && <span>{formatTime(task.start_time)}</span>}
-              {task.end_time && (
-                <>
-                  <span className='block'>~</span>
-                  <span>{formatTime(task.end_time)}</span>
-                </>
-              )}
+                )}
+                {task.memo && (
+                  <ul className='flex list-disc flex-col gap-y-[6px] text-[16px] font-medium'>
+                    <li className='ml-[20px]'>{task.memo}</li>
+                  </ul>
+                )}
+              </div>
+              <div className='text-right text-[20px] font-medium'>
+                {task.start_time && <span>{formatTime(task.start_time)}</span>}
+                {task.end_time && (
+                  <>
+                    <span className='block'>~</span>
+                    <span>{formatTime(task.end_time)}</span>
+                  </>
+                )}
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        className={`group relative min-h-[76px] w-[10px] rounded-r-[10px] transition-all duration-300 hover:w-[97px] hover:cursor-pointer ${task.is_completed ? 'bg-primary-100' : 'bg-primary-300'}`}
-      >
-        <div className='text-primary-0 invisible absolute top-0 left-0 flex h-full flex-col text-[18px] font-medium group-hover:visible'>
-          <button className='bg-primary-500 hover:bg-primary-600 h-full w-0 cursor-pointer overflow-hidden whitespace-nowrap transition-all duration-300 group-hover:w-[75px]'>
-            <span className='transform opacity-0 transition-all duration-300 group-hover:opacity-100'>
-              수정
-            </span>
-          </button>
-          <button className='bg-error-600 hover:bg-error-700 h-full w-0 cursor-pointer overflow-hidden whitespace-nowrap transition-all duration-300 group-hover:w-[75px]'>
-            <span className='transform opacity-0 transition-all duration-300 group-hover:opacity-100'>
-              삭제
-            </span>
-          </button>
+        <div
+          className={`group relative min-h-[76px] w-[10px] rounded-r-[10px] transition-all duration-300 hover:w-[97px] hover:cursor-pointer ${task.is_completed ? 'bg-primary-100' : 'bg-primary-300'}`}
+        >
+          <div className='text-primary-0 invisible absolute top-0 left-0 flex h-full flex-col text-[18px] font-medium group-hover:visible'>
+            <button
+              onClick={editTask}
+              className='bg-primary-500 hover:bg-primary-600 h-full w-0 cursor-pointer overflow-hidden whitespace-nowrap transition-all duration-300 group-hover:w-[75px]'
+            >
+              <span className='transform opacity-0 transition-all duration-300 group-hover:opacity-100'>
+                수정
+              </span>
+            </button>
+            <button className='bg-error-600 hover:bg-error-700 h-full w-0 cursor-pointer overflow-hidden whitespace-nowrap transition-all duration-300 group-hover:w-[75px]'>
+              <span className='transform opacity-0 transition-all duration-300 group-hover:opacity-100'>
+                삭제
+              </span>
+            </button>
+          </div>
         </div>
-      </div>
-    </li>
+      </li>
+      <TaskModal
+        mode={'edit'}
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        task={task}
+      />
+    </>
   );
 }
 

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -10,22 +10,22 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { TaskCalendar } from '@/app/_types';
+import { TaskCalendar, TaskPayload } from '@/app/_types';
 
 import 'react-day-picker/style.css';
 import DayPickerModal from './DayPickerModal';
 import { format } from 'date-fns';
 
-type Mode = 'add' | 'edit';
+type ModalMode = 'add' | 'edit';
 
 interface TaskModalProps {
-  mode: Mode;
+  mode: ModalMode | null;
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
-  task: TaskCalendar | null;
+  task: TaskPayload | null;
 }
 
-const modalMode: Record<Mode, { title: string; buttonLabel: string }> = {
+const modalMode: Record<ModalMode, { title: string; buttonLabel: string }> = {
   add: {
     title: 'Todo 추가',
     buttonLabel: '추가',
@@ -50,9 +50,17 @@ const initialTask = {
 
 const dateRegex = /(\d{4}\/\d{2}\/\d{2})/;
 
+const formattedTask = (task: TaskPayload) => ({
+  ...task,
+  start_time: new Date(task.start_time),
+  end_time: new Date(task.end_time),
+});
+
 function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
   const [isOpenDayPicker, setIsOpenDayPicker] = useState(false);
-  const [value, setValue] = useState<TaskCalendar>(initialTask);
+  const [value, setValue] = useState<TaskCalendar>(
+    task ? formattedTask(task) : initialTask,
+  );
   const DayAndTimeArray = format(value.start_time, 'yyyy/MM/dd hh:mm a').split(
     dateRegex,
   );
@@ -75,7 +83,9 @@ function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
     [],
   );
 
-  const handleSubmit = () => {};
+  const handleSubmit = () => {
+    setIsOpen(false);
+  };
 
   useEffect(() => {
     if (!task) return;
@@ -86,6 +96,8 @@ function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
       end_time: new Date(task.end_time),
     });
   }, [task]);
+
+  if (!mode) return;
 
   return (
     isOpen && (

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -99,6 +99,10 @@ function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
     setIsOpen(false);
   };
 
+  const handleSubmitDelete = () => {
+    setIsOpen(false);
+  };
+
   useEffect(() => {
     if (!task) return;
 
@@ -207,7 +211,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
             {modalMode[mode].deleteButtonLabel && (
               <SubmitButton
                 type='button'
-                onClick={handleSubmit}
+                onClick={handleSubmitDelete}
                 className='bg-error-600!'
               >
                 {modalMode[mode].deleteButtonLabel}

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -16,16 +16,19 @@ import 'react-day-picker/style.css';
 import DayPickerModal from './DayPickerModal';
 import { format } from 'date-fns';
 
-type ModalMode = 'add' | 'edit';
+export type ModalMode = 'add' | 'edit' | 'detail';
 
 interface TaskModalProps {
   mode: ModalMode | null;
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
-  task: TaskPayload | null;
+  task: TaskPayload | TaskCalendar | null;
 }
 
-const modalMode: Record<ModalMode, { title: string; buttonLabel: string }> = {
+const modalMode: Record<
+  ModalMode,
+  { title: string; buttonLabel: string; deleteButtonLabel?: string }
+> = {
   add: {
     title: 'Todo 추가',
     buttonLabel: '추가',
@@ -33,6 +36,11 @@ const modalMode: Record<ModalMode, { title: string; buttonLabel: string }> = {
   edit: {
     title: 'Todo 수정',
     buttonLabel: '수정',
+  },
+  detail: {
+    title: 'Todo 상세',
+    buttonLabel: '수정',
+    deleteButtonLabel: '삭제',
   },
 };
 
@@ -50,11 +58,15 @@ const initialTask = {
 
 const dateRegex = /(\d{4}\/\d{2}\/\d{2})/;
 
-const formattedTask = (task: TaskPayload) => ({
-  ...task,
-  start_time: new Date(task.start_time),
-  end_time: new Date(task.end_time),
-});
+const formattedTask = (task: TaskPayload | TaskCalendar): TaskCalendar => {
+  if (task.start_time instanceof Date) return task as TaskCalendar;
+
+  return {
+    ...task,
+    start_time: new Date(task.start_time),
+    end_time: new Date(task.end_time),
+  };
+};
 
 function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
   const [isOpenDayPicker, setIsOpenDayPicker] = useState(false);
@@ -188,9 +200,20 @@ function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
               />
             </fieldset>
           </form>
-          <SubmitButton type='button' onClick={handleSubmit}>
-            {modalMode[mode].buttonLabel}
-          </SubmitButton>
+          <div className='flex gap-[20px] *:flex-1'>
+            <SubmitButton type='button' onClick={handleSubmit}>
+              {modalMode[mode].buttonLabel}
+            </SubmitButton>
+            {modalMode[mode].deleteButtonLabel && (
+              <SubmitButton
+                type='button'
+                onClick={handleSubmit}
+                className='bg-error-600!'
+              >
+                {modalMode[mode].deleteButtonLabel}
+              </SubmitButton>
+            )}
+          </div>
         </div>
       </div>
     )


### PR DESCRIPTION
## 💡 작업 내용

- [x] `/calendar/daily` 페이지의 일정 추가 및 수정 모달 띄우기
- [x] `/calendar/monthly` 페이지의 일정 추가 및 상세보기(수정, 삭제기능) 모달 띄우기
- [x] `/calendar/weekly` 페이지 일정 추가 및 상세보기(수정, 삭제 기능) 모달 띄우기
- [x] TaskModal 상세보기 mode 추가

## 💡 자세한 설명

### 1️⃣ TaskModal 수정
#### TaskModal의 `task` prop 타입 수정 
`task` prop은 모달의 내용으로 들어갈 일정의 상세 내용을 전달받는데 `TaskPayload`, `TaskCalendar` 타입 모두 받을 수 있도록 수정했습니다. `TaskPayload` 타입일 경우 `formattedTask` 함수를 통해  `TaskCalender` 타입으로 변환됩니다. 
`TaskCalendar` 타입은 최종적으로 모달의 내용에 할당될 데이터로 사용됩니다. 

#### TaskModal를 통해 일정 상세보기 
ModalMode 유니온 타입에 `detail`을 추가했습니다. 
```ts
export type ModalMode = 'add' | 'edit' | 'detail';
```
`detail` 모드는 주간 및 월간 캘린더의 일정(event) 클릭 시 나타나는 모달에 사용되며 `수정`, `삭제` 버튼을 가지고 있습니다.

### 2️⃣ TaskListItem의 TaskProps 인터페이스 수정 
TaskListItem의 경우의 `수정` 버튼 클릭 시 수정 모달의 열리면서 task 데이터를 전달해야합니다. 
TaskListitem의 task prop은 서버로부터 응답받은 일정 데이터이므로 정의된 TaskPayload 타입으로 수정해주었습니다.
(모달의 props와 타입 일치 목적도 있습니다)

### 3️⃣ 스크린샷

![2025-04-09 14;44;34](https://github.com/user-attachments/assets/270ffb4e-202d-4ebe-a217-d8477f366d9c)


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
