### PR TITLE
feat: DayPickerModal 날짜 연속 선택 기능 구현 및 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@types/react-big-calendar": "^1.16.1",
         "axios": "^1.8.4",
         "date-fns": "^4.1.0",
+        "lodash": "^4.17.21",
         "next": "15.2.4",
         "react": "^19.0.0",
         "react-big-calendar": "^1.18.0",
@@ -20,6 +21,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/lodash": "^4.17.16",
         "@types/navermaps": "^3.7.9",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1197,6 +1199,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-big-calendar": "^1.16.1",
     "axios": "^1.8.4",
     "date-fns": "^4.1.0",
+    "lodash": "^4.17.21",
     "next": "15.2.4",
     "react": "^19.0.0",
     "react-big-calendar": "^1.18.0",
@@ -21,6 +22,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/lodash": "^4.17.16",
     "@types/navermaps": "^3.7.9",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/app/(afterlogin)/calendar/daily/page.tsx
+++ b/src/app/(afterlogin)/calendar/daily/page.tsx
@@ -4,7 +4,7 @@ import BoardTitle from '@/app/_components/common/BoardTitle';
 import Navigation from '@/app/_components/nav/Navigation';
 import TaskListItem from '@/app/_components/tasks/TaskListItem';
 import { TaskPayload } from '@/app/_types';
-import { formatTime } from '@/app/_utils';
+import { formatTime } from '@/app/_utils/dateTimeUtil';
 import { useEffect, useState } from 'react';
 import CalendarType from '../_components/CalendarType';
 import Progress from '../_components/Progress';
@@ -140,7 +140,10 @@ export default function Daily() {
                         <span>{formatTime(task.start_time)}</span>
                       </div>
                       <div className='bg-primary-0 border-primary-200 mt-[20px] flex h-[180px] items-center justify-center rounded-[10px] border-1'>
-                        <MapDisplay taskId={task.task_id} location={task.location} />
+                        <MapDisplay
+                          taskId={task.task_id}
+                          location={task.location}
+                        />
                       </div>
                     </div>
                   );

--- a/src/app/_components/common/NormalInput.tsx
+++ b/src/app/_components/common/NormalInput.tsx
@@ -3,12 +3,18 @@ import { ComponentPropsWithRef, ReactNode } from 'react';
 interface NormalInputProps extends ComponentPropsWithRef<'input'> {
   children?: ReactNode;
   className?: string;
+  isError?: boolean;
 }
 
-function NormalInput({ children, className = '', ...rest }: NormalInputProps) {
+function NormalInput({
+  children,
+  className = '',
+  isError = false,
+  ...rest
+}: NormalInputProps) {
   return (
     <div
-      className={`${className} bg-primary-0 border-primary-200 placeholder-secondary-400 flex gap-[16px] rounded-lg border p-[16px]`}
+      className={`${className} ${isError ? 'border-error-600 border-2' : 'border-primary-200 border'} bg-primary-0 placeholder-secondary-400 flex gap-[16px] rounded-lg p-[16px]`}
     >
       {children}
       <input

--- a/src/app/_components/tasks/DayPickerModal.tsx
+++ b/src/app/_components/tasks/DayPickerModal.tsx
@@ -2,84 +2,99 @@
 
 import useOutsideClick from '@/app/_hooks/useOutSideClick';
 import { TaskCalendar } from '@/app/_types';
-import { format, setHours, setMinutes } from 'date-fns';
-import {
-  ChangeEvent,
-  ChangeEventHandler,
-  Dispatch,
-  SetStateAction,
-  useEffect,
-  useState,
-} from 'react';
-import { DayPicker } from 'react-day-picker';
+import { applyTimeToDate } from '@/app/_utils/dateTimeUtil';
+import { format } from 'date-fns';
+import { ChangeEvent, useEffect, useState } from 'react';
+import { DateRange, DayPicker } from 'react-day-picker';
 
-interface DateAndTimePickerProps {
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
+interface DayPickerProps {
+  closeModal: () => void;
   onChange: (
     field: keyof TaskCalendar,
     e?: ChangeEvent<HTMLTextAreaElement>,
     value?: Date,
   ) => void;
-  value: Date;
+  value: DateRange;
 }
 
-function DayPickerModal({
-  setIsOpen,
-  onChange,
-  value,
-}: DateAndTimePickerProps) {
-  const pickerRef = useOutsideClick(() => setIsOpen(false));
-  const [selected, setSelected] = useState<Date>(value ?? new Date());
-  const [timeValue, setTimeValue] = useState<string>(
-    value ? format(value, 'hh:mm') : '00:00',
-  );
+interface TimeRange {
+  from: string;
+  to: string;
+}
 
-  const handleTimeChange: ChangeEventHandler<HTMLInputElement> = e => {
+function DayPickerModal({ closeModal, onChange, value }: DayPickerProps) {
+  const today = new Date();
+  const pickerRef = useOutsideClick(closeModal);
+  const [selected, setSelected] = useState<DateRange>({
+    from: value.from ?? today,
+    to: value.to ?? today,
+  });
+  const [timeValue, setTimeValue] = useState<TimeRange>({
+    from: value.from ? format(value.from, 'hh:mm') : '00:00',
+    to: value.to ? format(value.to, 'hh:mm') : '00:00',
+  });
+
+  const handleTimeChange = (
+    e: ChangeEvent<HTMLInputElement>,
+    field: 'from' | 'to',
+  ) => {
     const time = e.target.value;
-    if (!selected) {
-      setTimeValue(time);
-      return;
+    const date = selected[field];
+
+    if (!date) {
+      return setTimeValue(prev => ({ ...prev, [field]: time }));
     }
-    const [hours, minutes] = time.split(':').map(str => parseInt(str, 10));
-    const newSelectedDate = setHours(setMinutes(selected, minutes), hours);
-    setSelected(newSelectedDate);
-    setTimeValue(time);
+
+    setSelected(prev => ({ ...prev, [field]: applyTimeToDate(date, time) }));
+    setTimeValue(prev => ({ ...prev, [field]: time }));
   };
 
-  const handleDaySelect = (date: Date | undefined) => {
-    if (!timeValue || !date) {
-      if (date) setSelected(date);
-      return;
+  const handleDaySelect = (dates: DateRange) => {
+    if (!dates.from || !dates.to) {
+      return setSelected(dates);
     }
-    const [hours, minutes] = timeValue.split(':').map(str => parseInt(str, 10));
-    const newDate = new Date(
-      date.getFullYear(),
-      date.getMonth(),
-      date.getDate(),
-      hours,
-      minutes,
-    );
-    setSelected(newDate);
+
+    setSelected({
+      from: applyTimeToDate(dates.from, timeValue.from),
+      to: applyTimeToDate(dates.to, timeValue.to),
+    });
   };
 
   useEffect(() => {
     if (!selected) return;
 
-    onChange('start_time', undefined, selected);
+    onChange('start_time', undefined, selected.from);
+    onChange('end_time', undefined, selected.to ?? selected.from);
   }, [selected, onChange]);
 
   return (
     <div
       ref={pickerRef}
-      className='z-999 bg-primary-0 absolute mt-[46px] flex flex-col gap-[10px] rounded-[10px] p-2.5 shadow-lg'
+      className='bg-primary-0 absolute z-999 mt-[46px] flex gap-[10px] rounded-[10px] p-2.5 shadow-lg'
     >
       <DayPicker
+        required
         animate
-        mode='single'
+        mode='range'
         selected={selected}
         onSelect={handleDaySelect}
+        defaultMonth={selected.from ?? today}
+        min={1}
       />
-      <input type='time' value={timeValue} onChange={handleTimeChange} />
+      <div className='flex flex-col gap-[10px]'>
+        <label>시작 시간</label>
+        <input
+          type='time'
+          value={timeValue.from}
+          onChange={e => handleTimeChange(e, 'from')}
+        />
+        <label>종료 시간</label>
+        <input
+          type='time'
+          value={timeValue.to}
+          onChange={e => handleTimeChange(e, 'to')}
+        />
+      </div>
     </div>
   );
 }

--- a/src/app/_components/tasks/DayPickerModal.tsx
+++ b/src/app/_components/tasks/DayPickerModal.tsx
@@ -30,8 +30,8 @@ function DayPickerModal({ closeModal, onChange, value }: DayPickerProps) {
     to: value.to ?? today,
   });
   const [timeValue, setTimeValue] = useState<TimeRange>({
-    from: value.from ? format(value.from, 'hh:mm') : '00:00',
-    to: value.to ? format(value.to, 'hh:mm') : '00:00',
+    from: value.from ? format(value.from, 'HH:mm') : '00:00',
+    to: value.to ? format(value.to, 'HH:mm') : '00:00',
   });
 
   const handleTimeChange = (
@@ -82,14 +82,17 @@ function DayPickerModal({ closeModal, onChange, value }: DayPickerProps) {
         min={1}
       />
       <div className='flex flex-col gap-[10px]'>
-        <label>시작 시간</label>
+        <label htmlFor='startTime'>시작 시각</label>
         <input
+          id='startTime'
           type='time'
           value={timeValue.from}
           onChange={e => handleTimeChange(e, 'from')}
+          min={'14:00'}
         />
-        <label>종료 시간</label>
+        <label htmlFor='endTime'>종료 시각</label>
         <input
+          id='endTime'
           type='time'
           value={timeValue.to}
           onChange={e => handleTimeChange(e, 'to')}

--- a/src/app/_components/tasks/LocationModal.tsx
+++ b/src/app/_components/tasks/LocationModal.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import Image from 'next/image';
-import { Dispatch, SetStateAction, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import NormalInput from '../common/NormalInput';
 import SubmitButton from '../common/SubmitButton';
 import { searchLocation } from '@/app/_apis/searchLocation';
 import useOutsideClick from '@/app/_hooks/useOutSideClick';
 
 interface LocationModalProps {
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  closeModal: () => void;
   setPlaceName: (name: string) => void;
 }
 
@@ -24,14 +24,14 @@ interface SearchResult {
   telephone: string;
 }
 
-function LocationModal({ setIsOpen, setPlaceName }: LocationModalProps) {
-  const locationRef = useOutsideClick(() => setIsOpen(false));
+function LocationModal({ closeModal, setPlaceName }: LocationModalProps) {
+  const locationRef = useOutsideClick(closeModal);
   const inputRef = useRef<HTMLInputElement>(null);
   const [searchPlace, setSearchPlace] = useState('');
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
 
   const handleCloseButton = () => {
-    setIsOpen(false);
+    closeModal();
   };
 
   const handleSearchButton = async () => {
@@ -58,7 +58,7 @@ function LocationModal({ setIsOpen, setPlaceName }: LocationModalProps) {
 
   const handleSelectPlace = (selectedTitle: string) => {
     setPlaceName(selectedTitle);
-    setIsOpen(false);
+    closeModal();
   };
 
   return (

--- a/src/app/_components/tasks/TaskListItem.tsx
+++ b/src/app/_components/tasks/TaskListItem.tsx
@@ -1,4 +1,4 @@
-import { formatTime } from '@/app/_utils';
+import { formatTime } from '@/app/_utils/dateTimeUtil';
 import Image from 'next/image';
 import TaskModal from './TaskModal';
 import { useState } from 'react';

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -16,6 +16,7 @@ import 'react-day-picker/style.css';
 import DayPickerModal from './DayPickerModal';
 import { format, isEqual } from 'date-fns';
 import LocationModal from './LocationModal';
+import { validateDateTime } from '@/app/_utils/dateTimeUtil';
 
 export type ModalMode = 'add' | 'edit' | 'detail';
 
@@ -98,6 +99,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
   const [value, setValue] = useState<TaskCalendar>(
     task ? formattedTask(task) : initialTask,
   );
+  const [isInvalidDate, setIsInvalidDate] = useState(true);
 
   const handleCloseButton = () => {
     setIsOpen(false);
@@ -137,6 +139,10 @@ function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
     setValue(formattedTask(task));
   }, [task]);
 
+  useEffect(() => {
+    setIsInvalidDate(!validateDateTime(value.start_time, value.end_time));
+  }, [value]);
+
   if (!mode) return;
 
   return (
@@ -173,25 +179,36 @@ function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
               onClick={() => setOpenModal('dayPicker')}
             >
               <label htmlFor='date'>날짜</label>
-              <NormalInput readOnly className='*:last:hidden'>
-                <Image
-                  src='/assets/calendar-light.png'
-                  alt='calendar icon'
-                  width={24}
-                  height={24}
-                />
-                {formattedDateText(value.start_time, value.end_time)}
-                {openModal === 'dayPicker' && (
-                  <DayPickerModal
-                    closeModal={() => setOpenModal(null)}
-                    onChange={handleFieldChange}
-                    value={{
-                      from: value.start_time,
-                      to: value.end_time,
-                    }}
+              <div className='flex flex-col gap-[5px]'>
+                <NormalInput
+                  readOnly
+                  className='*:last:hidden'
+                  isError={isInvalidDate}
+                >
+                  <Image
+                    src='/assets/calendar-light.png'
+                    alt='calendar icon'
+                    width={24}
+                    height={24}
                   />
+                  {formattedDateText(value.start_time, value.end_time)}
+                  {openModal === 'dayPicker' && (
+                    <DayPickerModal
+                      closeModal={() => setOpenModal(null)}
+                      onChange={handleFieldChange}
+                      value={{
+                        from: value.start_time,
+                        to: value.end_time,
+                      }}
+                    />
+                  )}
+                </NormalInput>
+                {isInvalidDate && (
+                  <span className='text-error-600'>
+                    시작 시각이 종료 시각보다 늦습니다.
+                  </span>
                 )}
-              </NormalInput>
+              </div>
             </fieldset>
             <fieldset className={`relative items-center ${BASE_STYLE}`}>
               <label htmlFor='location'>위치</label>

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -14,7 +14,7 @@ import { TaskCalendar, TaskPayload } from '@/app/_types';
 
 import 'react-day-picker/style.css';
 import DayPickerModal from './DayPickerModal';
-import { format } from 'date-fns';
+import { format, isEqual } from 'date-fns';
 import LocationModal from './LocationModal';
 
 export type ModalMode = 'add' | 'edit' | 'detail';
@@ -57,33 +57,53 @@ const initialTask = {
   is_completed: false,
 };
 
-const dateRegex = /(\d{4}\/\d{2}\/\d{2})/;
-
 const formattedTask = (task: TaskPayload | TaskCalendar): TaskCalendar => {
   if (task.start_time instanceof Date) return task as TaskCalendar;
 
-  return {
-    ...task,
-    start_time: new Date(task.start_time),
-    end_time: new Date(task.end_time),
-  };
+  const start_time = new Date(task.start_time);
+  const end_time = task.end_time ? new Date(task.end_time) : start_time;
+
+  return { ...task, start_time, end_time };
+};
+
+const formattedDateText = (start: Date, end: Date) => {
+  const startDate = format(start, 'yyyy/MM/dd');
+  const startTime = format(start, 'hh:mm a');
+
+  if (isEqual(start, end)) {
+    return (
+      <span className='whitespace-nowrap'>
+        <strong>{startDate}</strong> {startTime}
+      </span>
+    );
+  }
+
+  const endDate = format(end, 'yyyy/MM/dd');
+  const endTime = format(end, 'hh:mm a');
+
+  return (
+    <span className='whitespace-nowrap'>
+      <strong>{startDate}</strong> {startTime} ~ <strong>{endDate}</strong>{' '}
+      {endTime}
+    </span>
+  );
 };
 
 function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
-  const [isOpenDayPicker, setIsOpenDayPicker] = useState(false);
-  const [isOpenLocationModal, setIsOpenLocationModal] = useState(false);
+  const BASE_STYLE =
+    'flex gap-[20px] *:first:text-xl *:first:font-semibold *:last:flex-1';
+  const [openModal, setOpenModal] = useState<null | 'dayPicker' | 'location'>(
+    null,
+  );
   const [value, setValue] = useState<TaskCalendar>(
     task ? formattedTask(task) : initialTask,
-  );
-  const DayAndTimeArray = format(value.start_time, 'yyyy/MM/dd hh:mm a').split(
-    dateRegex,
   );
 
   const handleCloseButton = () => {
     setIsOpen(false);
   };
 
-  const handleInputChange = useCallback(
+  const handleFieldChange = useCallback(
     (
       field: keyof TaskCalendar,
       e?: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -104,22 +124,17 @@ function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
     }));
   };
 
-  const handleSubmit = () => {
+  const handleConfirm = () => {
     setIsOpen(false);
   };
 
-  const handleSubmitDelete = () => {
+  const handleDelete = () => {
     setIsOpen(false);
   };
 
   useEffect(() => {
     if (!task) return;
-
-    setValue({
-      ...task,
-      start_time: new Date(task.start_time),
-      end_time: new Date(task.end_time),
-    });
+    setValue(formattedTask(task));
   }, [task]);
 
   if (!mode) return;
@@ -144,58 +159,48 @@ function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
           </div>
 
           <form className='mb-[20px] flex flex-col gap-[12px] rounded-[10px] bg-[#FAFAFA] p-2.5'>
-            <fieldset className='flex items-center gap-[20px] *:first:text-xl *:first:font-semibold *:last:flex-1'>
+            <fieldset className={`items-center ${BASE_STYLE}`}>
               <label htmlFor='title'>제목</label>
               <NormalInput
                 placeholder='제목'
                 value={value.title}
-                onChange={e => handleInputChange('title', e)}
+                onChange={e => handleFieldChange('title', e)}
                 required
               />
             </fieldset>
             <fieldset
-              className='flex items-center gap-[20px] *:first:text-xl *:first:font-semibold *:last:flex-1'
-              onClick={() => setIsOpenDayPicker(true)}
+              className={`items-center ${BASE_STYLE}`}
+              onClick={() => setOpenModal('dayPicker')}
             >
               <label htmlFor='date'>날짜</label>
-              <NormalInput
-                readOnly
-                placeholder={value.start_time ? '' : value.start_time}
-              >
+              <NormalInput readOnly className='*:last:hidden'>
                 <Image
                   src='/assets/calendar-light.png'
                   alt='calendar icon'
                   width={24}
                   height={24}
                 />
-                {
-                  <div>
-                    {DayAndTimeArray.map((part, index) => {
-                      return dateRegex.test(part) ? (
-                        <strong key={index}>{part}</strong>
-                      ) : (
-                        part
-                      );
-                    })}
-                  </div>
-                }
-                {isOpenDayPicker && (
+                {formattedDateText(value.start_time, value.end_time)}
+                {openModal === 'dayPicker' && (
                   <DayPickerModal
-                    setIsOpen={setIsOpenDayPicker}
-                    onChange={handleInputChange}
-                    value={value.start_time}
+                    closeModal={() => setOpenModal(null)}
+                    onChange={handleFieldChange}
+                    value={{
+                      from: value.start_time,
+                      to: value.end_time,
+                    }}
                   />
                 )}
               </NormalInput>
             </fieldset>
-            <fieldset className='relative flex items-center gap-[20px] *:first:text-xl *:first:font-semibold *:last:flex-1'>
+            <fieldset className={`relative items-center ${BASE_STYLE}`}>
               <label htmlFor='location'>위치</label>
               <div className='flex flex-grow justify-between'>
                 <NormalInput
                   placeholder='위치'
                   value={value.place_name}
                   className='mr-[10px] flex-grow'
-                  onChange={e => handleInputChange('place_name', e)}
+                  onChange={e => handleFieldChange('place_name', e)}
                 >
                   <Image
                     src='/assets/location-line.png'
@@ -207,35 +212,35 @@ function TaskModal({ mode, isOpen, setIsOpen, task }: TaskModalProps) {
                 <SubmitButton
                   type='button'
                   className='pr-[14px] pl-[14px] font-semibold'
-                  onClick={() => setIsOpenLocationModal(true)}
+                  onClick={() => setOpenModal('location')}
                 >
                   검색하기
                 </SubmitButton>
               </div>
-              {isOpenLocationModal && (
+              {openModal === 'location' && (
                 <LocationModal
-                  setIsOpen={setIsOpenLocationModal}
+                  closeModal={() => setOpenModal(null)}
                   setPlaceName={name => handlePlaceNameChange(name)}
                 />
               )}
             </fieldset>
-            <fieldset className='flex gap-[20px] *:first:mt-2 *:first:text-xl *:first:font-semibold *:last:flex-1'>
+            <fieldset className={`*:first:mt-2 ${BASE_STYLE}`}>
               <label htmlFor='memo'>메모</label>
               <NormalTextarea
                 placeholder='메모'
                 value={value.memo}
-                onChange={e => handleInputChange('memo', e)}
+                onChange={e => handleFieldChange('memo', e)}
               />
             </fieldset>
           </form>
           <div className='flex gap-[20px] *:flex-1'>
-            <SubmitButton type='button' onClick={handleSubmit}>
+            <SubmitButton type='button' onClick={handleConfirm}>
               {modalMode[mode].buttonLabel}
             </SubmitButton>
             {modalMode[mode].deleteButtonLabel && (
               <SubmitButton
                 type='button'
-                onClick={handleSubmitDelete}
+                onClick={handleDelete}
                 className='bg-error-600!'
               >
                 {modalMode[mode].deleteButtonLabel}

--- a/src/app/_utils/dateTimeUtil.ts
+++ b/src/app/_utils/dateTimeUtil.ts
@@ -1,4 +1,4 @@
-import { isBefore, isEqual, isSameDay, setHours, setMinutes } from 'date-fns';
+import { setHours, setMinutes } from 'date-fns';
 
 export const formatTime = (date: string | Date) => {
   return new Intl.DateTimeFormat('en-US', {
@@ -16,10 +16,4 @@ export const parseTimeString = (time: string): [number, number] => {
 export const applyTimeToDate = (date: Date, time: string) => {
   const [hours, minutes] = parseTimeString(time);
   return setHours(setMinutes(date, minutes), hours);
-};
-
-export const validateDateTime = (start: Date, end: Date) => {
-  if (!isSameDay(start, end) || isEqual(start, end)) return true;
-
-  return isBefore(start, end);
 };

--- a/src/app/_utils/dateTimeUtil.ts
+++ b/src/app/_utils/dateTimeUtil.ts
@@ -1,4 +1,4 @@
-import { setHours, setMinutes } from 'date-fns';
+import { isBefore, isEqual, isSameDay, setHours, setMinutes } from 'date-fns';
 
 export const formatTime = (date: string | Date) => {
   return new Intl.DateTimeFormat('en-US', {
@@ -16,4 +16,10 @@ export const parseTimeString = (time: string): [number, number] => {
 export const applyTimeToDate = (date: Date, time: string) => {
   const [hours, minutes] = parseTimeString(time);
   return setHours(setMinutes(date, minutes), hours);
+};
+
+export const validateDateTime = (start: Date, end: Date) => {
+  if (!isSameDay(start, end) || isEqual(start, end)) return true;
+
+  return isBefore(start, end);
 };

--- a/src/app/_utils/dateTimeUtil.ts
+++ b/src/app/_utils/dateTimeUtil.ts
@@ -1,0 +1,19 @@
+import { setHours, setMinutes } from 'date-fns';
+
+export const formatTime = (date: string | Date) => {
+  return new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).format(new Date(date));
+};
+
+export const parseTimeString = (time: string): [number, number] => {
+  const [hours, minutes] = time.split(':').map(str => parseInt(str, 10));
+  return [hours, minutes];
+};
+
+export const applyTimeToDate = (date: Date, time: string) => {
+  const [hours, minutes] = parseTimeString(time);
+  return setHours(setMinutes(date, minutes), hours);
+};

--- a/src/app/_utils/index.ts
+++ b/src/app/_utils/index.ts
@@ -1,9 +1,0 @@
-const formatTime = (date: string | Date) => {
-  return new Intl.DateTimeFormat('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  }).format(new Date(date));
-};
-
-export { formatTime };

--- a/src/app/_utils/validateUtil.ts
+++ b/src/app/_utils/validateUtil.ts
@@ -1,12 +1,24 @@
-import { isBefore, isEqual, isSameDay } from 'date-fns';
+import { isAfter, isEqual, isSameDay } from 'date-fns';
 
-export const validateBlank = (value: string) => {
-  if (value === '') return false;
-  return true;
+export const validateIsBlank = (value: string) => {
+  if (value === '') return true;
+  return false;
 };
 
-export const validateDateTime = (start: Date, end: Date) => {
-  if (!isSameDay(start, end) || isEqual(start, end)) return true;
+/**
+ * 같은 날짜일 때, 시작 시간이 종료 시간보다 늦은지 여부를 검증합니다.
+ *
+ * - 날짜가 다르면 항상 `false`를 반환합니다.
+ * - 시작과 종료 시각이 정확히 같아도 `false`를 반환합니다.
+ * - 같은 날짜이고, 시작 시간이 종료 시간보다 늦을 경우에만 `true`를 반환합니다.
+ *
+ * @param start - 시작 시각 (Date 객체)
+ * @param end - 종료 시각 (Date 객체)
+ * @returns `true` - 같은 날짜이고 시작 시간이 종료 시간보다 늦을 경우
+ *          `false` - 날짜가 다르거나, 같아도 시작 시간이 더 빠르거나 같은 경우
+ */
+export const validateIsAfterDateTime = (start: Date, end: Date) => {
+  if (!isSameDay(start, end) || isEqual(start, end)) return false;
 
-  return isBefore(start, end);
+  return isAfter(start, end);
 };

--- a/src/app/_utils/validateUtil.ts
+++ b/src/app/_utils/validateUtil.ts
@@ -1,0 +1,12 @@
+import { isBefore, isEqual, isSameDay } from 'date-fns';
+
+export const validateBlank = (value: string) => {
+  if (value === '') return false;
+  return true;
+};
+
+export const validateDateTime = (start: Date, end: Date) => {
+  if (!isSameDay(start, end) || isEqual(start, end)) return true;
+
+  return isBefore(start, end);
+};


### PR DESCRIPTION
## 💡 작업 내용

- DayPickerModal
  - [x] 날짜 연속 선택 기능 구현 
  - [x] 종료 시간 선택 기능 구현
- 리팩토링 
  - [x] date 및 time 관련 유틸 함수 `dateTimeUtils` 파일 분리 
  - [x] 중복되는 스타일 코드 BASE_STYLE 변수로 대체
  - [x] useEffect 내 중복되는 value 변환 코드는 formattedTask 함수 재사용
  - [x] DayPickerModal, LocationModal의 모달 열림, 닫힘 상태 useState 통합
  - [x] 직관적인 함수명으로 변경
  - [x] 날짜 선택 시 텍스트 형식 변환 및 스타일(굵기) 지정하는 복잡한 코드 함수로 분리


## 💡 자세한 설명

### 1️⃣ 날짜 연속 선택 및 종료 시간 선택 기능
![2025-04-15 01;26;15](https://github.com/user-attachments/assets/a0358577-721f-4178-a108-7a55d94f5ea8)

날짜를 `하루` 혹은 `연속된 날짜`로 선택할 수 있도록 기능을 추가했습니다. 
이에 맞게 시간도 `시작 시간`, `종료 시간`으로 나누어 선택할 수 있도록 추가했습니다. 

```tsx
<DayPicker
    required // 반드시 선택된 날짜가 존재하도록 함
    animate // 월 전환 시 부드러운 애니메이션 
    mode='range' // 기존에 `single` -> `range` 로 변경 ( 연속 날짜 선택 가능 )
    selected={selected}  // `DateRange` 타입의 날짜 데이터 
    onSelect={handleDaySelect} // 날짜 변경 시 호출되는 함수
    defaultMonth={selected.from ?? today} // 달력 열었을 때 기본으로 보여줄 달
    min={1} // 날짜 선택은 최소 1일
  />
```
`handleTimeChange` 와 `handleDaySelect` 함수에 사용되는 `applyTimeToDate` 유틸함수는 _utils/dateTimeUtil.ts 로 분리했습니다.

```ts
export const applyTimeToDate = (date: Date, time: string) => {
  const [hours, minutes] = parseTimeString(time); // 문자열 타입의 시간 데이터에서 시간과 분을 파싱하여 배열로 반환.
  return setHours(setMinutes(date, minutes), hours);
};
```
달력에서 날짜 혹은 시간을 선택했을 때 호출되며 선택된 날짜와 시간을 조합한 새로운 Date 타입을 반환합니다.


### 2️⃣ 리팩토링
유틸함수로 분리할 때 `index.ts`에 정의되어 있던 `formatTime` 함수도 같이 이동시켰습니다. 
그리고 전체적으로 중복되는 코드를 줄이고 좀 더 직관적인 네이밍으로 수정했습니다. 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

이해가 잘 되지않거나 가독성이 안좋은 코드가 있다면 말씀해주세요!!

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
