### PR TITLE
feat: 일정 조회 api 연동

### DIFF
--- a/src/app/(afterlogin)/calendar/daily/page.tsx
+++ b/src/app/(afterlogin)/calendar/daily/page.tsx
@@ -10,49 +10,25 @@ import CalendarType from '../_components/CalendarType';
 import Progress from '../_components/Progress';
 import MapDisplay from '../_components/MapDisplay';
 import TaskModal from '@/app/_components/tasks/TaskModal';
+import { fetchDailyTask } from '@/app/_apis/fetchTasks';
 
 export default function Daily() {
   const [isOpen, setIsOpen] = useState(false);
-  const [mockData, setMockData] = useState([
-    {
-      task_id: 1,
-      title: '일어나기',
-      memo: '',
-      start_time: '2025-03-11T13:00:00',
-      end_time: '',
-      address: '경기도 수원시 ...',
-      place_name: 'Cafe ABC',
-      location: { lat: '', lng: '' },
-      is_completed: true,
-    },
-    {
-      task_id: 2,
-      title: 'Team meeting',
-      memo: '주간 회의',
-      start_time: '2025-03-11T13:00:00',
-      end_time: '',
-      address: '경기도 수원시 ...',
-      place_name: 'Zep 4번 룸',
-      location: { lat: '37.484543', lng: '127.010808' },
-      is_completed: false,
-    },
-    {
-      task_id: 3,
-      title: '구현하기',
-      memo: '수요일까지 구현해요',
-      start_time: '2025-03-11T13:00:00',
-      end_time: '2025-03-11T14:00:00',
-      address: '경기도 수원시 ...',
-      place_name: 'Cafe DEF',
-      location: { lat: '37.498014', lng: '127.027616' },
-      is_completed: false,
-    },
-  ]);
+  const [taskList, setTaskList] = useState<TaskPayload[]>([]);
   const [pendingTask, setPendingTask] = useState<TaskPayload[]>([]);
   const [finishedTaskCount, setFinishedTaskCount] = useState(0);
 
+  const getTodayTask = async (todayDate: Date) => {
+    try {
+      const result = await fetchDailyTask(todayDate);
+      setTaskList(result);
+    } catch (error) {
+      console.error('오늘의 일정을 불러오는 중 에러가 발생했습니다. ', error);
+    }
+  };
+
   const handleCheckClick = (taskId: number) => {
-    setMockData(prev =>
+    setTaskList(prev =>
       prev.map(task =>
         task.task_id === taskId
           ? { ...task, is_completed: !task.is_completed }
@@ -64,9 +40,13 @@ export default function Daily() {
   const addTask = () => setIsOpen(true);
 
   useEffect(() => {
-    setFinishedTaskCount(mockData.filter(task => task.is_completed).length);
-    setPendingTask(mockData.filter(task => !task.is_completed));
-  }, [mockData]);
+    getTodayTask(new Date());
+  }, []);
+
+  useEffect(() => {
+    setFinishedTaskCount(taskList.filter(task => task.is_completed).length);
+    setPendingTask(taskList.filter(task => !task.is_completed));
+  }, [taskList]);
 
   return (
     <div className='text-secondary-500 inline-flex h-full min-h-screen w-full bg-[#FAFAFA]'>
@@ -77,7 +57,7 @@ export default function Daily() {
             <CalendarType />
             <Progress
               finishedTaskCount={finishedTaskCount}
-              totalTaskCount={mockData.length}
+              totalTaskCount={taskList.length}
             />
           </BoardTitle>
           <div className='flex h-full justify-between bg-[#FAFAFA] px-[32px] py-[24px]'>
@@ -90,7 +70,7 @@ export default function Daily() {
                 ></button>
               </div>
               <ul className='flex flex-col gap-y-[10px]'>
-                {mockData.map((task, index) => {
+                {taskList.map((task, index) => {
                   return (
                     <TaskListItem
                       task={task}
@@ -119,10 +99,10 @@ export default function Daily() {
                             출발
                           </span>
                           <span className='text-[20px] font-semibold'>
-                            {mockData[0].task_id === task.task_id
+                            {taskList[0].task_id === task.task_id
                               ? 'House'
                               : index === 0
-                                ? mockData[task.task_id - 2].place_name
+                                ? taskList[task.task_id - 2].place_name
                                 : pendingTask[index - 1].place_name}
                           </span>
                         </div>
@@ -137,12 +117,12 @@ export default function Daily() {
                             {task.place_name}
                           </span>
                         </div>
-                        <span>{formatTime(task.start_time)}</span>
+                        <span>{formatTime(task.end_time)}</span>
                       </div>
                       <div className='bg-primary-0 border-primary-200 mt-[20px] flex h-[180px] items-center justify-center rounded-[10px] border-1'>
                         <MapDisplay
                           taskId={task.task_id}
-                          location={task.location}
+                          location={{ lat: task.latitude, lng: task.longitude }}
                         />
                       </div>
                     </div>

--- a/src/app/(afterlogin)/calendar/daily/page.tsx
+++ b/src/app/(afterlogin)/calendar/daily/page.tsx
@@ -69,18 +69,22 @@ export default function Daily() {
                   className='bg-primary-400 hover:bg-primary-500 h-[40px] w-[40px] cursor-pointer rounded-[10px] bg-[url(/assets/plus-small.png)] bg-center bg-no-repeat'
                 ></button>
               </div>
-              <ul className='flex flex-col gap-y-[10px]'>
-                {taskList.map((task, index) => {
-                  return (
-                    <TaskListItem
-                      task={task}
-                      index={index}
-                      key={task.task_id}
-                      handleCheckClick={handleCheckClick}
-                    />
-                  );
-                })}
-              </ul>
+              {taskList.length === 0 ? (
+                <div className='w-full text-center mt-30'>일정이 없습니다</div>
+              ) : (
+                <ul className='flex flex-col gap-y-[10px]'>
+                  {taskList.map((task, index) => {
+                    return (
+                      <TaskListItem
+                        task={task}
+                        index={index}
+                        key={task.task_id}
+                        handleCheckClick={handleCheckClick}
+                      />
+                    );
+                  })}
+                </ul>
+              )}
             </div>
             <div className='min-w-[400px]'>
               <div className='mb-[18px]'>

--- a/src/app/(afterlogin)/calendar/daily/page.tsx
+++ b/src/app/(afterlogin)/calendar/daily/page.tsx
@@ -10,7 +10,7 @@ import CalendarType from '../_components/CalendarType';
 import Progress from '../_components/Progress';
 import MapDisplay from '../_components/MapDisplay';
 import TaskModal from '@/app/_components/tasks/TaskModal';
-import { fetchDailyTask } from '@/app/_apis/fetchTasks';
+import { getDailyTask } from '@/app/_apis/getTasks';
 
 export default function Daily() {
   const [isOpen, setIsOpen] = useState(false);
@@ -18,9 +18,9 @@ export default function Daily() {
   const [pendingTask, setPendingTask] = useState<TaskPayload[]>([]);
   const [finishedTaskCount, setFinishedTaskCount] = useState(0);
 
-  const getTodayTask = async (todayDate: Date) => {
+  const fetchDailyTask = async (todayDate: Date) => {
     try {
-      const result = await fetchDailyTask(todayDate);
+      const result = await getDailyTask(todayDate);
       setTaskList(result);
     } catch (error) {
       console.error('오늘의 일정을 불러오는 중 에러가 발생했습니다. ', error);
@@ -40,7 +40,7 @@ export default function Daily() {
   const addTask = () => setIsOpen(true);
 
   useEffect(() => {
-    getTodayTask(new Date());
+    fetchDailyTask(new Date());
   }, []);
 
   useEffect(() => {

--- a/src/app/(afterlogin)/calendar/monthly/page.tsx
+++ b/src/app/(afterlogin)/calendar/monthly/page.tsx
@@ -12,7 +12,7 @@ import CalendarType from '../_components/CalendarType';
 import Progress from '../_components/Progress';
 import CalendarContainer from '../_components/CalendarContainer';
 import TaskModal from '@/app/_components/tasks/TaskModal';
-import { fetchMonthlyTask } from '@/app/_apis/fetchTasks';
+import { getMonthlyTask } from '@/app/_apis/getTasks';
 
 export default function Monthly() {
   const [isOpen, setIsOpen] = useState(false);
@@ -34,18 +34,18 @@ export default function Monthly() {
     setSelectEvent(event);
   }, []);
 
-  const getMonthlyTask = async (todayDate: Date) => {
+  const fetchMonthlyTask = async (todayDate: Date) => {
     try {
-      const result = await fetchMonthlyTask(todayDate);
+      const result = await getMonthlyTask(todayDate);
       setTaskList(result);
     } catch (error) {
       console.error('오늘의 일정을 불러오는 중 에러가 발생했습니다. ', error);
     }
-  }
+  };
 
   useEffect(() => {
-    getMonthlyTask(new Date());
-  }, [])
+    fetchMonthlyTask(new Date());
+  }, []);
 
   useEffect(() => {
     if (taskList && taskList.length > 0) {

--- a/src/app/(afterlogin)/calendar/weekly/page.tsx
+++ b/src/app/(afterlogin)/calendar/weekly/page.tsx
@@ -18,7 +18,7 @@ import Progress from '../_components/Progress';
 import CalendarContainer from '../_components/CalendarContainer';
 import { TaskCalendar, TaskPayload } from '@/app/_types';
 import TaskModal from '@/app/_components/tasks/TaskModal';
-import { fetchWeeklyTask } from '@/app/_apis/fetchTasks';
+import { getWeeklyTask } from '@/app/_apis/getTasks';
 
 export default function Weekly() {
   const [isOpen, setIsOpen] = useState(false);
@@ -67,9 +67,9 @@ export default function Weekly() {
     [taskList],
   );
 
-  const getWeeklyTask = async (todayDate: Date) => {
+  const fetchWeeklyTask = async (todayDate: Date) => {
     try {
-      const result = await fetchWeeklyTask(todayDate);
+      const result = await getWeeklyTask(todayDate);
       setTaskList(result);
     } catch (error) {
       console.error('오늘의 일정을 불러오는 중 에러가 발생했습니다. ', error);
@@ -82,7 +82,7 @@ export default function Weekly() {
   }, []);
 
   useEffect(() => {
-    getWeeklyTask(new Date());
+    fetchWeeklyTask(new Date());
   }, []);
 
   return (

--- a/src/app/(afterlogin)/calendar/weekly/page.tsx
+++ b/src/app/(afterlogin)/calendar/weekly/page.tsx
@@ -8,7 +8,7 @@ import { getDay } from 'date-fns/getDay';
 import { ko } from 'date-fns/locale';
 import './weeklyCalendar.css';
 import { Calendar, dateFnsLocalizer, DateLocalizer } from 'react-big-calendar';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import BoardTitle from '@/app/_components/common/BoardTitle';
 import { isEqual } from 'date-fns';
 import CustomWeekEvent from './CustomWeekEvent';
@@ -18,52 +18,20 @@ import Progress from '../_components/Progress';
 import CalendarContainer from '../_components/CalendarContainer';
 import { TaskCalendar, TaskPayload } from '@/app/_types';
 import TaskModal from '@/app/_components/tasks/TaskModal';
+import { fetchWeeklyTask } from '@/app/_apis/fetchTasks';
 
 export default function Weekly() {
   const [isOpen, setIsOpen] = useState(false);
   const [selectEvent, setSelectEvent] = useState<TaskCalendar | null>(null);
-  const [mockData] = useState<TaskPayload[]>([
-    {
-      task_id: 1,
-      title: '일어나기',
-      memo: '',
-      start_time: '2025-04-07T08:00:00',
-      end_time: '2025-04-07T10:00:00',
-      address: '경기도 수원시 ...',
-      place_name: 'Cafe ABC',
-      location: { lat: '', lng: '' },
-      is_completed: true,
-    },
-    {
-      task_id: 2,
-      title: 'Team meeting',
-      memo: '주간 회의',
-      start_time: '2025-04-11T15:00:00',
-      end_time: '',
-      address: '경기도 수원시 ...',
-      place_name: 'Zep 4번 룸',
-      location: { lat: '127.1086228', lng: '37.4012191' },
-      is_completed: false,
-    },
-    {
-      task_id: 3,
-      title: '구현하기',
-      memo: '수요일까지 구현해요',
-      start_time: '2025-04-11T13:00:00',
-      end_time: '2025-04-13T14:00:00',
-      address: '경기도 수원시 ...',
-      place_name: 'Cafe DEF',
-      location: { lat: '127.1086228', lng: '37.4012191' },
-      is_completed: false,
-    },
-  ]);
-  const finishedTaskCount = mockData
-    ? mockData.filter(task => task.is_completed).length
+  const [taskList, setTaskList] = useState<TaskPayload[]>([]);
+
+  const finishedTaskCount = taskList
+    ? taskList.filter(task => task.is_completed).length
     : 0;
 
   const { formats, components, events, localizer } = useMemo(
     () => ({
-      events: mockData.map(task => {
+      events: taskList.map(task => {
         const start = new Date(task.start_time);
         const end = new Date(task.end_time || task.start_time);
 
@@ -96,12 +64,25 @@ export default function Weekly() {
         },
       },
     }),
-    [mockData],
+    [taskList],
   );
+
+  const getWeeklyTask = async (todayDate: Date) => {
+    try {
+      const result = await fetchWeeklyTask(todayDate);
+      setTaskList(result);
+    } catch (error) {
+      console.error('오늘의 일정을 불러오는 중 에러가 발생했습니다. ', error);
+    }
+  };
 
   const onSelectEvent = useCallback((event: TaskCalendar) => {
     setIsOpen(true);
     setSelectEvent(event);
+  }, []);
+
+  useEffect(() => {
+    getWeeklyTask(new Date());
   }, []);
 
   return (
@@ -113,7 +94,7 @@ export default function Weekly() {
             <CalendarType />
             <Progress
               finishedTaskCount={finishedTaskCount}
-              totalTaskCount={mockData.length}
+              totalTaskCount={taskList.length}
             />
           </BoardTitle>
           <CalendarContainer>

--- a/src/app/_apis/fetchTasks.ts
+++ b/src/app/_apis/fetchTasks.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { TaskPayload } from '../_types';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_SERVER_URL,
+});
+
+export const fetchDailyTask = async (date: Date): Promise<TaskPayload[]> => {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  try {
+    const response = await api.get('/tasks/day', {
+      params: { year, month, day },
+    });
+
+    return response.data.data;
+  } catch (error) {
+    console.error('API 호출 중 에러가 발생했습니다.', error);
+    return [];
+  }
+};

--- a/src/app/_apis/fetchTasks.ts
+++ b/src/app/_apis/fetchTasks.ts
@@ -22,10 +22,29 @@ export const fetchDailyTask = async (date: Date): Promise<TaskPayload[]> => {
   }
 };
 
+export const fetchWeeklyTask = async (date: Date): Promise<TaskPayload[]> => {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
+  const firstDayOfWeek = firstDay.getDay();
+  const week = Math.ceil((date.getDate() + firstDayOfWeek) / 7);
+
+  try {
+    const response = await api.get('/tasks/week', {
+      params: { year, month, week },
+    });
+
+    return response.data.data;
+  } catch (error) {
+    console.error('API 호출 중 에러가 발생했습니다.', error);
+    return [];
+  }
+};
+
 export const fetchMonthlyTask = async (date: Date): Promise<TaskPayload[]> => {
   const year = date.getFullYear();
   const month = date.getMonth() + 1;
-  
+
   try {
     const response = await api.get('/tasks/month', {
       params: { year, month },
@@ -36,4 +55,4 @@ export const fetchMonthlyTask = async (date: Date): Promise<TaskPayload[]> => {
     console.error('API 호출 중 에러가 발생했습니다.', error);
     return [];
   }
-}
+};

--- a/src/app/_apis/fetchTasks.ts
+++ b/src/app/_apis/fetchTasks.ts
@@ -21,3 +21,19 @@ export const fetchDailyTask = async (date: Date): Promise<TaskPayload[]> => {
     return [];
   }
 };
+
+export const fetchMonthlyTask = async (date: Date): Promise<TaskPayload[]> => {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  
+  try {
+    const response = await api.get('/tasks/month', {
+      params: { year, month },
+    });
+
+    return response.data.data;
+  } catch (error) {
+    console.error('API 호출 중 에러가 발생했습니다.', error);
+    return [];
+  }
+}

--- a/src/app/_apis/getTasks.ts
+++ b/src/app/_apis/getTasks.ts
@@ -29,33 +29,29 @@ const formatDateParams = (date: Date, type: 'day' | 'week' | 'month') => {
   return dateParams;
 };
 
-const fetchTasks = async (
+const getTasks = async (
   endpoint: string,
   params: TaskParams,
 ): Promise<TaskPayload[]> => {
-  try {
-    const response = await api.get(endpoint, { params });
-    return response.data.data;
-  } catch (error) {
-    console.error('API 호출 중 에러가 발생했습니다.', error);
-    return [];
-  }
+  const response = await api.get(endpoint, { params });
+
+  return response.data.data;
 };
 
-export const fetchDailyTask = (date: Date): Promise<TaskPayload[]> => {
+export const getDailyTask = (date: Date): Promise<TaskPayload[]> => {
   const params = formatDateParams(date, 'day');
 
-  return fetchTasks('/tasks/day', params);
+  return getTasks('/tasks/day', params);
 };
 
-export const fetchWeeklyTask = (date: Date): Promise<TaskPayload[]> => {
+export const getWeeklyTask = (date: Date): Promise<TaskPayload[]> => {
   const params = formatDateParams(date, 'week');
 
-  return fetchTasks('/tasks/week', params);
+  return getTasks('/tasks/week', params);
 };
 
-export const fetchMonthlyTask = (date: Date): Promise<TaskPayload[]> => {
+export const getMonthlyTask = (date: Date): Promise<TaskPayload[]> => {
   const params = formatDateParams(date, 'month');
-  
-  return fetchTasks('/tasks/month', params);
+
+  return getTasks('/tasks/month', params);
 };

--- a/src/app/_types/index.ts
+++ b/src/app/_types/index.ts
@@ -4,7 +4,8 @@ export interface Task {
   memo: string;
   address: string;
   place_name: string;
-  location: { lat: string; lng: string };
+  latitude: string;
+  longitude: string;
   is_completed: boolean;
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -105,18 +105,22 @@ export default function Dashboard() {
             totalTaskCount={taskList.length}
           />
           <div className='text-secondary-500 mt-[14px]'>
-            <ul className='flex flex-col gap-y-[10px]'>
-              {taskList.map((task, index) => {
-                return (
-                  <TaskListItem
-                    task={task}
-                    index={index}
-                    key={task.task_id}
-                    handleCheckClick={handleCheckClick}
-                  />
-                );
-              })}
-            </ul>
+            {taskList.length === 0 ? (
+              <div className='mt-30 text-center'>일정이 없습니다</div>
+            ) : (
+              <ul className='flex flex-col gap-y-[10px]'>
+                {taskList.map((task, index) => {
+                  return (
+                    <TaskListItem
+                      task={task}
+                      index={index}
+                      key={task.task_id}
+                      handleCheckClick={handleCheckClick}
+                    />
+                  );
+                })}
+              </ul>
+            )}
           </div>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,8 +7,10 @@ import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { fetchDailyTask } from './_apis/fetchTasks';
 import { TaskPayload } from './_types';
+import TaskModal from './_components/tasks/TaskModal';
 
 export default function Dashboard() {
+  const [isOpen, setIsOpen] = useState(false);
   const [currentTime, setCurrentTime] = useState('');
   const [today, setToday] = useState('');
   const [taskList, setTaskList] = useState<TaskPayload[]>([]);
@@ -44,6 +46,8 @@ export default function Dashboard() {
     );
   };
 
+  const addTask = () => setIsOpen(true);
+
   useEffect(() => {
     const interval = setInterval(() => {
       getCurrentTime();
@@ -72,7 +76,7 @@ export default function Dashboard() {
   }, [taskList]);
 
   return (
-    <div className='flex h-full min-h-screen min-w-[1440px] bg-[#FAFAFA]'>
+    <div className='text-secondary-500 flex h-full min-h-screen min-w-[1440px] bg-[#FAFAFA]'>
       <Navigation />
       <div className='w-full min-w-[752px]'>
         <div className='p-[32px]'>
@@ -86,7 +90,10 @@ export default function Dashboard() {
               </span>
             </div>
             <div className='flex items-end'>
-              <button className='bg-primary-400 hover:bg-primary-500 h-[50px] w-[50px] cursor-pointer rounded-[10px] bg-[url(/assets/plus-big.png)] bg-center bg-no-repeat'></button>
+              <button
+                onClick={addTask}
+                className='bg-primary-400 hover:bg-primary-500 h-[50px] w-[50px] cursor-pointer rounded-[10px] bg-[url(/assets/plus-big.png)] bg-center bg-no-repeat'
+              ></button>
             </div>
           </div>
           <div className='text-secondary-500 mt-[35px] mb-[12px] flex justify-between text-[20px] font-semibold'>
@@ -140,6 +147,7 @@ export default function Dashboard() {
           </div>
         </div>
       </div>
+      <TaskModal mode='add' isOpen={isOpen} setIsOpen={setIsOpen} task={null} />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,46 +5,23 @@ import ProgressBar from '@/app/_components/tasks/ProgressBar';
 import TaskListItem from '@/app/_components/tasks/TaskListItem';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
+import { fetchDailyTask } from './_apis/fetchTasks';
+import { TaskPayload } from './_types';
 
 export default function Dashboard() {
   const [currentTime, setCurrentTime] = useState('');
   const [today, setToday] = useState('');
-  const [mockData, setMockData] = useState([
-    {
-      task_id: 1,
-      title: '일어나기',
-      memo: '',
-      start_time: '2025-03-11T13:00:00',
-      end_time: '',
-      address: '경기도 수원시 ...',
-      place_name: 'Cafe ABC',
-      location: { lat: '', lng: '' },
-      is_completed: true,
-    },
-    {
-      task_id: 2,
-      title: 'Team meeting',
-      memo: '주간 회의',
-      start_time: '2025-03-11T13:00:00',
-      end_time: '',
-      address: '경기도 수원시 ...',
-      place_name: 'Zep 4번 룸',
-      location: { lat: '127.1086228', lng: '37.4012191' },
-      is_completed: false,
-    },
-    {
-      task_id: 3,
-      title: '구현하기',
-      memo: '수요일까지 구현해요',
-      start_time: '2025-03-11T13:00:00',
-      end_time: '2025-03-11T14:00:00',
-      address: '경기도 수원시 ...',
-      place_name: 'Cafe ABC',
-      location: { lat: '127.1086228', lng: '37.4012191' },
-      is_completed: false,
-    },
-  ]);
+  const [taskList, setTaskList] = useState<TaskPayload[]>([]);
   const [finishedTaskCount, setFinishedTaskCount] = useState(0);
+
+  const getTodayTask = async (todayDate: Date) => {
+    try {
+      const result = await fetchDailyTask(todayDate);
+      setTaskList(result);
+    } catch (error) {
+      console.error('오늘의 일정을 불러오는 중 에러가 발생했습니다. ', error);
+    }
+  };
 
   const getCurrentTime = () => {
     const currentDate = new Date();
@@ -58,7 +35,7 @@ export default function Dashboard() {
   };
 
   const handleCheckClick = (taskId: number) => {
-    setMockData(prev =>
+    setTaskList(prev =>
       prev.map(task =>
         task.task_id === taskId
           ? { ...task, is_completed: !task.is_completed }
@@ -68,7 +45,6 @@ export default function Dashboard() {
   };
 
   useEffect(() => {
-    getCurrentTime();
     const interval = setInterval(() => {
       getCurrentTime();
     }, 1000);
@@ -88,11 +64,12 @@ export default function Dashboard() {
         ' ' +
         weekday,
     );
+    getTodayTask(todayDate);
   }, []);
 
   useEffect(() => {
-    setFinishedTaskCount(mockData.filter(task => task.is_completed).length);
-  }, [mockData]);
+    setFinishedTaskCount(taskList.filter(task => task.is_completed).length);
+  }, [taskList]);
 
   return (
     <div className='flex h-full min-h-screen min-w-[1440px] bg-[#FAFAFA]'>
@@ -114,15 +91,15 @@ export default function Dashboard() {
           </div>
           <div className='text-secondary-500 mt-[35px] mb-[12px] flex justify-between text-[20px] font-semibold'>
             <span>Task Done</span>
-            <span>{`${finishedTaskCount} / ${mockData.length}`}</span>
+            <span>{`${finishedTaskCount} / ${taskList.length}`}</span>
           </div>
           <ProgressBar
             finishedTaskCount={finishedTaskCount}
-            totalTaskCount={mockData.length}
+            totalTaskCount={taskList.length}
           />
           <div className='text-secondary-500 mt-[14px]'>
             <ul className='flex flex-col gap-y-[10px]'>
-              {mockData.map((task, index) => {
+              {taskList.map((task, index) => {
                 return (
                   <TaskListItem
                     task={task}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import ProgressBar from '@/app/_components/tasks/ProgressBar';
 import TaskListItem from '@/app/_components/tasks/TaskListItem';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
-import { fetchDailyTask } from './_apis/fetchTasks';
+import { getDailyTask } from './_apis/getTasks';
 import { TaskPayload } from './_types';
 import TaskModal from './_components/tasks/TaskModal';
 
@@ -16,9 +16,9 @@ export default function Dashboard() {
   const [taskList, setTaskList] = useState<TaskPayload[]>([]);
   const [finishedTaskCount, setFinishedTaskCount] = useState(0);
 
-  const getTodayTask = async (todayDate: Date) => {
+  const fetchDailyTask = async (todayDate: Date) => {
     try {
-      const result = await fetchDailyTask(todayDate);
+      const result = await getDailyTask(todayDate);
       setTaskList(result);
     } catch (error) {
       console.error('오늘의 일정을 불러오는 중 에러가 발생했습니다. ', error);
@@ -68,7 +68,7 @@ export default function Dashboard() {
         ' ' +
         weekday,
     );
-    getTodayTask(todayDate);
+    fetchDailyTask(todayDate);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## 💡 작업 내용

- [x] 일정 조회 api 추가
- [x] 대시보드에 일간 일정 조회 api 연동
- [x] 일간, 주간, 월간 일정 페이지에 각각의 일정 조회 api 연동

## 💡 자세한 설명

### 1️⃣ 일정 조회 api 추가
axios를 사용하여 일정을 조회하는 함수를 `_apis/fetchTasks.ts` 파일에 작성하였습니다. 공통적으로 사용되는 날짜 파라미터 만드는 부분과 api 호출 부분을 함수로 분리해 두었습니다.

원래 사용했던 Task 인터페이스는 다음과 같이 location 내부에 lat, lng을 받아오는 형식이었는데
```tsx
{
    ...
    location: {
        lat: string;
        lng: string;
    }
}
```
백엔드 데이터를 확인해보니 데이터가 다음과 같이 오고 있었습니다.
```json
{
            ...
            "latitude": "37.4980954",
            "longitude": "127.0276104",
}
```
따라서 Task를 백엔드에서 오는 것과 같이 `latitude`, `longitude`로 변경하였습니다.

### 2️⃣ 일정 조회 api 연동
각각의 일정 페이지에 조회 api를 연동해 두었습니다. 기존에 있던 mock 데이터는 삭제해 두었습니다.
연동하면서 대시보드 페이지에 일정 추가 모달이 빠져있는 것을 확인하여 추가해두었습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
