### PR TITLE
fix: 일정 저장 시 데이터 형식 수정

### DIFF
--- a/src/app/(afterlogin)/calendar/_components/MapDisplay.tsx
+++ b/src/app/(afterlogin)/calendar/_components/MapDisplay.tsx
@@ -4,8 +4,8 @@ import { useEffect, useMemo, useRef } from 'react';
 interface mapProps {
   taskId: number;
   location: {
-    lat: string;
-    lng: string;
+    lat: number;
+    lng: number;
   };
 }
 
@@ -16,8 +16,8 @@ function MapDisplay({ taskId, location }: mapProps) {
     if (!location || !location.lat || !location.lng) return null;
 
     return new naver.maps.LatLng(
-      parseFloat(location.lat),
-      parseFloat(location.lng),
+      location.lat,
+      location.lng,
     );
   }, [location]);
 

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -26,6 +26,7 @@ import useAddTaskMutation from '@/app/_hooks/useAddTaskMutation';
 import useEditTaskMutation from '@/app/_hooks/useEditTaskMutation';
 import useDeleteTaskMutation from '@/app/_hooks/useDeleteTaskMutation';
 import { toZonedTime } from 'date-fns-tz';
+import { GeoSearchResult } from '@/app/_types/location';
 
 export type ModalMode = 'add' | 'edit' | 'detail';
 
@@ -64,8 +65,8 @@ const initialTask = {
   end_time: new Date(),
   address: '',
   place_name: '',
-  latitude: '',
-  longitude: '',
+  latitude: 0,
+  longitude: 0,
   is_completed: false,
 };
 
@@ -134,10 +135,13 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
     [],
   );
 
-  const handlePlaceNameChange = (name: string) => {
+  const handlePlaceChange = (place: GeoSearchResult) => {
     setValue(prev => ({
       ...prev,
-      place_name: name,
+      longitude: place.mapx,
+      latitude: place.mapy,
+      place_name: place.title,
+      address: place.address,
     }));
   };
 
@@ -294,7 +298,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
               {openModal === 'location' && (
                 <LocationModal
                   closeModal={() => setOpenModal(null)}
-                  setPlaceName={name => handlePlaceNameChange(name)}
+                  setPlace={place => handlePlaceChange(place)}
                 />
               )}
             </fieldset>

--- a/src/app/_types/index.ts
+++ b/src/app/_types/index.ts
@@ -4,8 +4,8 @@ export interface Task {
   memo: string;
   address: string;
   place_name: string;
-  latitude: string;
-  longitude: string;
+  latitude: number;
+  longitude: number;
   is_completed: boolean;
 }
 

--- a/src/app/_types/location.ts
+++ b/src/app/_types/location.ts
@@ -1,0 +1,20 @@
+export interface LocationResult {
+  title: string;
+  address: string;
+  category: string;
+  description: string;
+  link: string;
+  roadAddress: string;
+  telephone: string;
+}
+
+export interface RawSearchResult extends LocationResult {
+  mapx: string;
+  mapy: string;
+}
+
+export interface GeoSearchResult extends LocationResult {
+  mapx: number;
+  mapy: number;
+}
+


### PR DESCRIPTION
## 💡 작업 내용

- [x] 장소 검색 타입 인터페이스로 분리
- [x] 좌표 타입 number로 변경
- [x] 백엔드에 보내는 데이터 추가

## 💡 자세한 설명

### 1️⃣ 장소 검색 타입 분리
`SearchResult` 로 사용하고 있던 타입을 LocationResult로 분리하였습니다.
좌표값으로 사용하고 있는 mapx, mapy는 소수점을 제거한 형태의 string으로 오기 때문에, 소수점을 넣은 number 형태로 변경된 데이터를 사용하기 위해 2가지로 나누었습니다.
```tsx
export interface LocationResult {
  title: string;
  address: string;
  category: string;
  description: string;
  link: string;
  roadAddress: string;
  telephone: string;
}

export interface RawSearchResult extends LocationResult {
  mapx: string;
  mapy: string;
}

export interface GeoSearchResult extends LocationResult {
  mapx: number;
  mapy: number;
}
```
**RawSearchResult** : 네이버 장소 검색 결과로 받아오는 데이터로, mapx와 mapy가 string 형태의 데이터입니다.
**GeoSearchResult**: 실제 프로젝트에서 사용되는 데이터로, 장소 검색 결과의 좌표 데이터를 숫자로 변경한 데이터입니다. 

### 2️⃣ 좌표 타입 number로 변경 및 백엔드에 보내는 데이터 추가
사용하는 좌표를 `number` 타입으로 변경하였습니다. 또한 백엔드에 유효성 검사가 추가되면서, address, latitude, longitude가 없는 경우 에러가 발생합니다. 따라서 해당 부분을 추가하여 보내도록 함수를 수정하였습니다.

`LocationModal.tsx`의 다음과 같은 부분에서 확인할 수 있습니다.
```tsx
      const parsedResults: GeoSearchResult[] = results.data.map(
        (result: RawSearchResult) => ({
          ...result,
          title: result.title.replace(/<[^>]*>/g, ''),
          mapx: parseInt(result.mapx) / 10000000,
          mapy: parseInt(result.mapy) / 10000000,
        }),
      );
```
받아온 string 값을 파싱하여 좌표 숫자값으로 만들어주는 부분입니다. 채연님이 기존에 구현해두신 cleanTitle의 정규표현식 부분도 해당 map안으로 옮겨 바로 title에 넣을 수 있도록 하였습니다!

또한 해당 부분의 변경으로 인해 기존의 `selectedTitle` 및 `setPlaceName`과 같은 네이밍을 `selectedPlace`, `setPlace`와 같이 전체적인 장소 데이터 변경의 의미가 되도록 수정하였습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
