### PR TITLE
feat: 일정 소요시간, 길찾기 기능 구현

### DIFF
--- a/src/app/(afterlogin)/calendar/_components/RouteInfo.tsx
+++ b/src/app/(afterlogin)/calendar/_components/RouteInfo.tsx
@@ -1,0 +1,27 @@
+import { TaskWithDuration } from '@/app/_types';
+import { formatTime } from '@/app/_utils/dateTimeUtil';
+
+interface RouteInfoProps {
+  label: string;
+  task: TaskWithDuration;
+}
+
+function RouteInfo({ label, task }: RouteInfoProps) {
+  return (
+    <div className='mb-[10px] flex items-center justify-between'>
+      <div className='truncate overflow-hidden text-ellipsis'>
+        <span className='mr-[10px] text-[20px] font-bold'>{label}</span>
+        <span className='text-[20px] font-semibold'>
+          {label === '출발' ? task.from_place_name : task.place_name}
+        </span>
+      </div>
+      <span className='font-medium whitespace-nowrap'>
+        {label === '출발'
+          ? formatTime(task.start_time)
+          : formatTime(task.end_time)}
+      </span>
+    </div>
+  );
+}
+
+export default RouteInfo;

--- a/src/app/(afterlogin)/calendar/daily/page.tsx
+++ b/src/app/(afterlogin)/calendar/daily/page.tsx
@@ -3,7 +3,7 @@
 import BoardTitle from '@/app/_components/common/BoardTitle';
 import Navigation from '@/app/_components/nav/Navigation';
 import TaskListItem from '@/app/_components/tasks/TaskListItem';
-import { TaskPayload } from '@/app/_types';
+import { TaskWithDuration } from '@/app/_types';
 import { formatTime } from '@/app/_utils/dateTimeUtil';
 import { useEffect, useState } from 'react';
 import CalendarType from '../_components/CalendarType';
@@ -14,7 +14,7 @@ import useGetTaskQuery from '@/app/_hooks/useGetTaskQuery';
 
 export default function Daily() {
   const [isOpen, setIsOpen] = useState(false);
-  const [pendingTask, setPendingTask] = useState<TaskPayload[]>([]);
+  const [pendingTask, setPendingTask] = useState<TaskWithDuration[]>([]);
   const [finishedTaskCount, setFinishedTaskCount] = useState(0);
 
   const { data: taskList = [] } = useGetTaskQuery('day');
@@ -27,7 +27,7 @@ export default function Daily() {
   }, [taskList]);
 
   return (
-    <div className='text-secondary-500 inline-flex h-full min-h-screen min-w-[1500px] w-full bg-[#FAFAFA]'>
+    <div className='text-secondary-500 inline-flex h-full min-h-screen w-full min-w-[1500px] bg-[#FAFAFA]'>
       <Navigation />
       <div className='bg-primary-0 h-full w-full min-w-[752px]'>
         <div className='flex flex-col'>
@@ -39,7 +39,7 @@ export default function Daily() {
             />
           </BoardTitle>
           <div className='flex h-full justify-between bg-[#FAFAFA] px-[32px] py-[24px]'>
-            <div className='mr-[34px] min-w-[752px] w-full'>
+            <div className='mr-[34px] w-full min-w-[752px]'>
               <div className='mb-[18px] flex justify-between'>
                 <span className='text-[24px] font-semibold'>Todos</span>
                 <button
@@ -62,47 +62,80 @@ export default function Daily() {
                 <span className='text-[24px] font-semibold'>Next moves</span>
               </div>
               <div className='flex flex-col gap-[18px]'>
-                {pendingTask.map((task, index) => {
-                  return (
-                    <div
-                      key={task.task_id}
-                      className='bg-primary-0 border-primary-200 w-full rounded-[10px] border-1 px-[64px] py-[23px]'
-                    >
-                      <div className='mb-[10px] flex items-center justify-between'>
-                        <div>
-                          <span className='mr-[10px] text-[20px] font-bold'>
-                            출발
-                          </span>
-                          <span className='text-[20px] font-semibold'>
-                            {taskList[0].task_id === task.task_id
-                              ? 'House'
-                              : index === 0
-                                ? taskList[task.task_id - 2].place_name
-                                : pendingTask[index - 1].place_name}
-                          </span>
+                {pendingTask
+                  .filter(task => task.place_name !== '')
+                  .map(task => {
+                    return (
+                      <div
+                        key={task.task_id}
+                        className='bg-primary-0 border-primary-200 w-full rounded-[10px] border-1 px-[64px] py-[23px]'
+                      >
+                        {task.from_place_name && (
+                          <div className='mb-[10px] flex items-center justify-between'>
+                            <div className='truncate overflow-hidden text-ellipsis'>
+                              <span className='mr-[10px] text-[20px] font-bold'>
+                                출발
+                              </span>
+                              <span className='text-[20px] font-semibold'>
+                                {task.from_place_name}
+                              </span>
+                            </div>
+                            <span className='font-medium whitespace-nowrap'>
+                              {formatTime(task.start_time)}
+                            </span>
+                          </div>
+                        )}
+                        {task.place_name && (
+                          <div className='mb-[10px] flex items-center justify-between'>
+                            <div className='truncate overflow-hidden text-ellipsis'>
+                              <span className='mr-[10px] text-[20px] font-bold'>
+                                도착
+                              </span>
+                              <span className='text-[20px] font-semibold'>
+                                {task.place_name}
+                              </span>
+                            </div>
+                            <span className='font-medium whitespace-nowrap'>
+                              {formatTime(task.end_time)}
+                            </span>
+                          </div>
+                        )}
+                        {task.travel_duration && (
+                          <div className='mb-[10px] flex items-center justify-between'>
+                            <div>
+                              <span className='mr-[10px] text-[20px] font-bold'>
+                                소요시간
+                              </span>
+                            </div>
+                            <span className='bg-primary-200 rounded-[5px] px-[4px] py-[2px] text-[16px] font-bold'>
+                              {task.travel_duration}
+                            </span>
+                          </div>
+                        )}
+                        {task.travel_duration && (
+                          <div className='flex items-center justify-between'>
+                            <div>
+                              <span className='mr-[10px] text-[20px] font-bold'>
+                                추천 출발시각
+                              </span>
+                            </div>
+                            <span className='bg-primary-200 rounded-[5px] px-[4px] py-[2px] text-[16px] font-bold'>
+                              {task.recommended_departure_time}
+                            </span>
+                          </div>
+                        )}
+                        <div className='bg-primary-0 border-primary-200 mt-[20px] flex h-[180px] items-center justify-center rounded-[10px] border-1'>
+                          <MapDisplay
+                            taskId={task.task_id}
+                            location={{
+                              lat: task.latitude,
+                              lng: task.longitude,
+                            }}
+                          />
                         </div>
-                        <span>{formatTime(task.start_time)}</span>
                       </div>
-                      <div className='flex items-center justify-between'>
-                        <div>
-                          <span className='mr-[10px] text-[20px] font-bold'>
-                            도착
-                          </span>
-                          <span className='text-[20px] font-semibold'>
-                            {task.place_name}
-                          </span>
-                        </div>
-                        <span>{formatTime(task.end_time)}</span>
-                      </div>
-                      <div className='bg-primary-0 border-primary-200 mt-[20px] flex h-[180px] items-center justify-center rounded-[10px] border-1'>
-                        <MapDisplay
-                          taskId={task.task_id}
-                          location={{ lat: task.latitude, lng: task.longitude }}
-                        />
-                      </div>
-                    </div>
-                  );
-                })}
+                    );
+                  })}
               </div>
             </div>
           </div>

--- a/src/app/(afterlogin)/calendar/daily/page.tsx
+++ b/src/app/(afterlogin)/calendar/daily/page.tsx
@@ -27,7 +27,7 @@ export default function Daily() {
   }, [taskList]);
 
   return (
-    <div className='text-secondary-500 inline-flex h-full min-h-screen w-full bg-[#FAFAFA]'>
+    <div className='text-secondary-500 inline-flex h-full min-h-screen min-w-[1500px] w-full bg-[#FAFAFA]'>
       <Navigation />
       <div className='bg-primary-0 h-full w-full min-w-[752px]'>
         <div className='flex flex-col'>
@@ -39,7 +39,7 @@ export default function Daily() {
             />
           </BoardTitle>
           <div className='flex h-full justify-between bg-[#FAFAFA] px-[32px] py-[24px]'>
-            <div className='mr-[34px] min-w-[752px]'>
+            <div className='mr-[34px] min-w-[752px] w-full'>
               <div className='mb-[18px] flex justify-between'>
                 <span className='text-[24px] font-semibold'>Todos</span>
                 <button

--- a/src/app/(afterlogin)/calendar/daily/page.tsx
+++ b/src/app/(afterlogin)/calendar/daily/page.tsx
@@ -131,6 +131,10 @@ export default function Daily() {
                               lat: task.latitude,
                               lng: task.longitude,
                             }}
+                            enabled={
+                              task.from_place_name !== '' &&
+                              task.place_name !== ''
+                            }
                           />
                         </div>
                       </div>

--- a/src/app/(afterlogin)/calendar/daily/page.tsx
+++ b/src/app/(afterlogin)/calendar/daily/page.tsx
@@ -4,13 +4,13 @@ import BoardTitle from '@/app/_components/common/BoardTitle';
 import Navigation from '@/app/_components/nav/Navigation';
 import TaskListItem from '@/app/_components/tasks/TaskListItem';
 import { TaskWithDuration } from '@/app/_types';
-import { formatTime } from '@/app/_utils/dateTimeUtil';
 import { useEffect, useState } from 'react';
 import CalendarType from '../_components/CalendarType';
 import Progress from '../_components/Progress';
 import MapDisplay from '../_components/MapDisplay';
 import TaskModal from '@/app/_components/tasks/TaskModal';
 import useGetTaskQuery from '@/app/_hooks/useGetTaskQuery';
+import RouteInfo from '../_components/RouteInfo';
 
 export default function Daily() {
   const [isOpen, setIsOpen] = useState(false);
@@ -71,34 +71,10 @@ export default function Daily() {
                         className='bg-primary-0 border-primary-200 w-full rounded-[10px] border-1 px-[64px] py-[23px]'
                       >
                         {task.from_place_name && (
-                          <div className='mb-[10px] flex items-center justify-between'>
-                            <div className='truncate overflow-hidden text-ellipsis'>
-                              <span className='mr-[10px] text-[20px] font-bold'>
-                                출발
-                              </span>
-                              <span className='text-[20px] font-semibold'>
-                                {task.from_place_name}
-                              </span>
-                            </div>
-                            <span className='font-medium whitespace-nowrap'>
-                              {formatTime(task.start_time)}
-                            </span>
-                          </div>
+                          <RouteInfo label='출발' task={task} />
                         )}
                         {task.place_name && (
-                          <div className='mb-[10px] flex items-center justify-between'>
-                            <div className='truncate overflow-hidden text-ellipsis'>
-                              <span className='mr-[10px] text-[20px] font-bold'>
-                                도착
-                              </span>
-                              <span className='text-[20px] font-semibold'>
-                                {task.place_name}
-                              </span>
-                            </div>
-                            <span className='font-medium whitespace-nowrap'>
-                              {formatTime(task.end_time)}
-                            </span>
-                          </div>
+                          <RouteInfo label='도착' task={task} />
                         )}
                         {task.travel_duration && (
                           <div className='mb-[10px] flex items-center justify-between'>

--- a/src/app/_apis/tasks.ts
+++ b/src/app/_apis/tasks.ts
@@ -56,6 +56,12 @@ export const getMonthlyTask = (date: Date): Promise<TaskWithDuration[]> => {
   return getTasks('/tasks/month', params);
 };
 
+export const getTaskPath = async (taskId: number): Promise<[number, number][]> => {
+  const response = await api.get(`/tasks/${taskId}/path`);
+
+  return response.data.data.path;
+};
+
 export const postTask = async (task: TaskPayload) => {
   const response = await api.post('/tasks', task);
 

--- a/src/app/_apis/tasks.ts
+++ b/src/app/_apis/tasks.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { TaskPayload } from '../_types';
+import { TaskPayload, TaskWithDuration } from '../_types';
 import { getWeekOfMonth } from 'date-fns';
 
 type TaskParams = {
@@ -32,25 +32,25 @@ const formatDateParams = (date: Date, type: 'day' | 'week' | 'month') => {
 const getTasks = async (
   endpoint: string,
   params: TaskParams,
-): Promise<TaskPayload[]> => {
+): Promise<TaskWithDuration[]> => {
   const response = await api.get(endpoint, { params });
 
   return response.data.data;
 };
 
-export const getDailyTask = (date: Date): Promise<TaskPayload[]> => {
+export const getDailyTask = (date: Date): Promise<TaskWithDuration[]> => {
   const params = formatDateParams(date, 'day');
 
   return getTasks('/tasks/day', params);
 };
 
-export const getWeeklyTask = (date: Date): Promise<TaskPayload[]> => {
+export const getWeeklyTask = (date: Date): Promise<TaskWithDuration[]> => {
   const params = formatDateParams(date, 'week');
 
   return getTasks('/tasks/week', params);
 };
 
-export const getMonthlyTask = (date: Date): Promise<TaskPayload[]> => {
+export const getMonthlyTask = (date: Date): Promise<TaskWithDuration[]> => {
   const params = formatDateParams(date, 'month');
 
   return getTasks('/tasks/month', params);

--- a/src/app/_components/tasks/LocationModal.tsx
+++ b/src/app/_components/tasks/LocationModal.tsx
@@ -62,7 +62,7 @@ function LocationModal({ closeModal, setPlace }: LocationModalProps) {
   return (
     <div
       ref={locationRef}
-      className='bg-primary-0 absolute top-1/2 left-1/2 w-[550px] -translate-x-1/2 -translate-y-1/2 transform rounded-[10px] p-2.5 px-[40px] py-[30px] shadow-[0_0_30px_0_rgba(84,87,122,0.7)]'
+      className='bg-primary-0 absolute top-1/2 left-1/2 z-10 w-[550px] -translate-x-1/2 -translate-y-1/2 transform rounded-[10px] p-2.5 px-[40px] py-[30px] shadow-[0_0_30px_0_rgba(84,87,122,0.7)]'
     >
       <div className='mb-[30px] flex justify-between'>
         <p className='text-[24px] font-semibold'>장소 검색</p>

--- a/src/app/_components/tasks/TaskListItem.tsx
+++ b/src/app/_components/tasks/TaskListItem.tsx
@@ -90,7 +90,7 @@ function TaskListItem({ task }: TaskProps) {
               </div>
               <div className='text-right text-[20px] font-medium'>
                 {task.start_time && <span>{formatTime(task.start_time)}</span>}
-                {task.end_time && (
+                {task.end_time !== '' && task.end_time !== task.start_time && (
                   <>
                     <span className='block'>~</span>
                     <span>{formatTime(task.end_time)}</span>

--- a/src/app/_components/tasks/TaskListItem.tsx
+++ b/src/app/_components/tasks/TaskListItem.tsx
@@ -54,6 +54,20 @@ function TaskListItem({ task }: TaskProps) {
                 className={`ml-[19px] text-[20px] font-semibold ${task.is_completed && 'line-through'}`}
               >
                 <span>{task.title}</span>
+                {task.from_place_name && (
+                  <div className='mt-[10px] mb-[10px] flex text-[16px] font-medium'>
+                    <div className='mr-[5px] h-[20px] w-[20px]'>
+                      <Image
+                        src={`${task.is_completed ? '/assets/location-light.png' : '/assets/location.png'}`}
+                        width={20}
+                        height={20}
+                        alt='location icon'
+                      />
+                    </div>
+                    <span className='mr-[6px]'>출발 : </span>
+                    {task.from_place_name}
+                  </div>
+                )}
                 {task.place_name && (
                   <div className='mt-[10px] mb-[10px] flex text-[16px] font-medium'>
                     <div className='mr-[5px] h-[20px] w-[20px]'>
@@ -64,6 +78,7 @@ function TaskListItem({ task }: TaskProps) {
                         alt='location icon'
                       />
                     </div>
+                    <span className='mr-[6px]'>도착 : </span>
                     {task.place_name}
                   </div>
                 )}

--- a/src/app/_components/tasks/TaskListItem.tsx
+++ b/src/app/_components/tasks/TaskListItem.tsx
@@ -12,7 +12,7 @@ interface TaskProps {
 
 function TaskListItem({ task }: TaskProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const { mutate: editTaskMutate } = useEditTaskMutation('day');
+  const { mutate: editTaskMutate } = useEditTaskMutation('day', task.task_id);
   const { mutate: deleteTaskMutate } = useDeleteTaskMutation('day');
 
   const editTask = () => {

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -294,33 +294,6 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
               <div className='flex flex-grow justify-between'>
                 <NormalInput
                   placeholder='출발 위치'
-                  value={value.place_name || ''}
-                  className='mr-[10px] flex-grow'
-                  onChange={e => handleFieldChange('place_name', e)}
-                >
-                  <Image
-                    src='/assets/location-line.png'
-                    alt='calendar icon'
-                    width={24}
-                    height={24}
-                  />
-                </NormalInput>
-                <SubmitButton
-                  type='button'
-                  className='pr-[14px] pl-[14px] font-semibold'
-                  onClick={() =>
-                    setOpenModal({ type: 'location', target: 'place_name' })
-                  }
-                >
-                  검색하기
-                </SubmitButton>
-              </div>
-            </fieldset>
-            <fieldset className={`relative items-center ${BASE_STYLE}`}>
-              <label htmlFor='location'>도착</label>
-              <div className='flex flex-grow justify-between'>
-                <NormalInput
-                  placeholder='도착 위치'
                   value={value.from_place_name || ''}
                   className='mr-[10px] flex-grow'
                   onChange={e => handleFieldChange('from_place_name', e)}
@@ -339,6 +312,36 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
                     setOpenModal({
                       type: 'location',
                       target: 'from_place_name',
+                    })
+                  }
+                >
+                  검색하기
+                </SubmitButton>
+              </div>
+            </fieldset>
+            <fieldset className={`relative items-center ${BASE_STYLE}`}>
+              <label htmlFor='location'>도착</label>
+              <div className='flex flex-grow justify-between'>
+                <NormalInput
+                  placeholder='도착 위치'
+                  value={value.place_name || ''}
+                  className='mr-[10px] flex-grow'
+                  onChange={e => handleFieldChange('place_name', e)}
+                >
+                  <Image
+                    src='/assets/location-line.png'
+                    alt='calendar icon'
+                    width={24}
+                    height={24}
+                  />
+                </NormalInput>
+                <SubmitButton
+                  type='button'
+                  className='pr-[14px] pl-[14px] font-semibold'
+                  onClick={() =>
+                    setOpenModal({
+                      type: 'location',
+                      target: 'place_name',
                     })
                   }
                 >

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -67,6 +67,11 @@ const initialTask = {
   place_name: '',
   latitude: 0,
   longitude: 0,
+  from_lat: 0,
+  from_lng: 0,
+  from_address: '',
+  from_place_name: '',
+  route_option: 'trafast',
   is_completed: false,
 };
 
@@ -104,7 +109,10 @@ const renderDate = (start: Date, end: Date) => {
   );
 };
 
-type NestedModalType = null | 'dayPicker' | 'location';
+type NestedModalType =
+  | null
+  | { type: 'dayPicker' }
+  | { type: 'location'; target: 'place_name' | 'from_place_name' };
 
 function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
   const [openModal, setOpenModal] = useState<NestedModalType>(null);
@@ -135,14 +143,24 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
     [],
   );
 
-  const handlePlaceChange = (place: GeoSearchResult) => {
-    setValue(prev => ({
-      ...prev,
-      longitude: place.mapx,
-      latitude: place.mapy,
-      place_name: place.title,
-      address: place.address,
-    }));
+  const handlePlaceChange = (place: GeoSearchResult, target: string) => {
+    if (target === 'from_place_name') {
+      setValue(prev => ({
+        ...prev,
+        from_lng: place.mapx,
+        from_lat: place.mapy,
+        from_place_name: place.title,
+        from_address: place.address,
+      }));
+    } else {
+      setValue(prev => ({
+        ...prev,
+        longitude: place.mapx,
+        latitude: place.mapy,
+        place_name: place.title,
+        address: place.address,
+      }));
+    }
   };
 
   const handleSaveTask = () => {
@@ -237,7 +255,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
             </fieldset>
             <fieldset
               className={`items-center ${BASE_STYLE}`}
-              onClick={() => setOpenModal('dayPicker')}
+              onClick={() => setOpenModal({ type: 'dayPicker' })}
             >
               <label htmlFor='date'>날짜</label>
               <div className='flex flex-col gap-[5px]'>
@@ -253,7 +271,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
                     height={24}
                   />
                   {renderDate(value.start_time, value.end_time)}
-                  {openModal === 'dayPicker' && (
+                  {openModal?.type === 'dayPicker' && (
                     <DayPickerModal
                       closeModal={() => setOpenModal(null)}
                       onChange={handleFieldChange}
@@ -272,10 +290,10 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
               </div>
             </fieldset>
             <fieldset className={`relative items-center ${BASE_STYLE}`}>
-              <label htmlFor='location'>위치</label>
+              <label htmlFor='location'>출발</label>
               <div className='flex flex-grow justify-between'>
                 <NormalInput
-                  placeholder='위치'
+                  placeholder='출발 위치'
                   value={value.place_name || ''}
                   className='mr-[10px] flex-grow'
                   onChange={e => handleFieldChange('place_name', e)}
@@ -290,15 +308,47 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
                 <SubmitButton
                   type='button'
                   className='pr-[14px] pl-[14px] font-semibold'
-                  onClick={() => setOpenModal('location')}
+                  onClick={() =>
+                    setOpenModal({ type: 'location', target: 'place_name' })
+                  }
                 >
                   검색하기
                 </SubmitButton>
               </div>
-              {openModal === 'location' && (
+            </fieldset>
+            <fieldset className={`relative items-center ${BASE_STYLE}`}>
+              <label htmlFor='location'>도착</label>
+              <div className='flex flex-grow justify-between'>
+                <NormalInput
+                  placeholder='도착 위치'
+                  value={value.from_place_name || ''}
+                  className='mr-[10px] flex-grow'
+                  onChange={e => handleFieldChange('from_place_name', e)}
+                >
+                  <Image
+                    src='/assets/location-line.png'
+                    alt='calendar icon'
+                    width={24}
+                    height={24}
+                  />
+                </NormalInput>
+                <SubmitButton
+                  type='button'
+                  className='pr-[14px] pl-[14px] font-semibold'
+                  onClick={() =>
+                    setOpenModal({
+                      type: 'location',
+                      target: 'from_place_name',
+                    })
+                  }
+                >
+                  검색하기
+                </SubmitButton>
+              </div>
+              {openModal?.type === 'location' && (
                 <LocationModal
                   closeModal={() => setOpenModal(null)}
-                  setPlace={place => handlePlaceChange(place)}
+                  setPlace={place => handlePlaceChange(place, openModal.target)}
                 />
               )}
             </fieldset>

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -126,7 +126,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
     'flex gap-[20px] *:first:text-xl *:first:font-semibold *:last:flex-1';
 
   const { mutate: addTaskMutate } = useAddTaskMutation(type);
-  const { mutate: editTaskMutate } = useEditTaskMutation(type);
+  const { mutate: editTaskMutate } = useEditTaskMutation(type, task?.task_id);
   const { mutate: deleteTaskMutate } = useDeleteTaskMutation(type);
 
   const handleFieldChange = useCallback(

--- a/src/app/_hooks/useEditTaskMutation.ts
+++ b/src/app/_hooks/useEditTaskMutation.ts
@@ -2,7 +2,10 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { patchTask } from '../_apis/tasks';
 import { format } from 'date-fns';
 
-const useEditTaskMutation = (type: 'day' | 'week' | 'month') => {
+const useEditTaskMutation = (
+  type: 'day' | 'week' | 'month',
+  taskId: number | undefined,
+) => {
   const queryClient = useQueryClient();
   const date = format(new Date(), 'yyyy-MM-dd');
 
@@ -12,6 +15,9 @@ const useEditTaskMutation = (type: 'day' | 'week' | 'month') => {
     onError: error => console.error('일정 수정 실패:', error),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['getTask', type, date] });
+      if (taskId !== undefined) {
+        queryClient.invalidateQueries({ queryKey: [taskId] });
+      }
     },
   });
 };

--- a/src/app/_hooks/useGetPathQuery.ts
+++ b/src/app/_hooks/useGetPathQuery.ts
@@ -3,7 +3,7 @@ import { getTaskPath } from '../_apis/tasks';
 
 const useGetPathQuery = (taskId: number, enabled: boolean) => {
   return useQuery({
-    queryKey: [taskId],
+    queryKey: ['getPath', taskId],
     queryFn: () => {
       return getTaskPath(taskId);
     },

--- a/src/app/_hooks/useGetPathQuery.ts
+++ b/src/app/_hooks/useGetPathQuery.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { getTaskPath } from '../_apis/tasks';
+
+const useGetPathQuery = (taskId: number, enabled: boolean) => {
+  return useQuery({
+    queryKey: [taskId],
+    queryFn: () => {
+      return getTaskPath(taskId);
+    },
+    enabled,
+  });
+};
+
+export default useGetPathQuery;

--- a/src/app/_types/index.ts
+++ b/src/app/_types/index.ts
@@ -6,6 +6,11 @@ export interface Task {
   place_name: string;
   latitude: number;
   longitude: number;
+  from_lat: number;
+  from_lng: number;
+  from_address: string;
+  from_place_name: string;
+  route_option: string;
   is_completed: boolean;
 }
 

--- a/src/app/_types/index.ts
+++ b/src/app/_types/index.ts
@@ -19,6 +19,15 @@ export interface TaskPayload extends Task {
   end_time: string;
 }
 
+export interface TaskWithDuration extends Task {
+  start_time: string;
+  end_time: string;
+  route_option: string;
+  recommended_departure_time: string;
+  travel_distance: string;
+  travel_duration: string;
+}
+
 export interface TaskCalendar extends Task {
   start_time: Date;
   end_time: Date;


### PR DESCRIPTION
## 💡 작업 내용

- [x] 일정 소요시간 추가
- [x] 길찾기 이동경로 표시
- [x] 일정 등록 시 출발/도착 위치를 각각 받도록 변경 

## 💡 자세한 설명

### 1️⃣ 일정 타입 수정
백엔드에서 요청하는 데이터가 변경됨에 따라서 모달에 사용되는 타입에 다음과 같은 내용이 추가되었습니다.
```tsx
  from_lat: number;
  from_lng: number;
  from_address: string;
  from_place_name: string;
  route_option: string;
```
현재 route_option은 'trafast' (실시간 빠른 길)로 static 데이터를 넣어 보내고 있는데, 추후 설정 탭에서 사용자가 선택할 수 있도록 해야 할 것 같습니다.

또한 일정 조회 시 소요시간 데이터를 포함한 값이 반환됨에 따라 다음과 같은 타입을 새로 지정해두었습니다.
```tsx
export interface TaskWithDuration extends Task {
  start_time: string;
  end_time: string;
  route_option: string;
  recommended_departure_time: string;
  travel_distance: string;
  travel_duration: string;
}
```

### 2️⃣ 일정 모달 수정
일정 모달에서는 등록/수정 시 출발/도착 위치를 각각 받을 수 있도록 변경하였습니다.
<img width="500" alt="Screenshot 2025-04-24 at 10 27 50 am" src="https://github.com/user-attachments/assets/f9877b7e-0e1a-4f2b-9a09-e1015f6168a9" />
```tsx
  const handlePlaceChange = (place: GeoSearchResult, target: string) => {
    if (target === 'from_place_name') {
      setValue(prev => ({
        ...prev,
        from_lng: place.mapx,
        from_lat: place.mapy,
        from_place_name: place.title,
        from_address: place.address,
      }));
    } else {
      setValue(prev => ({
        ...prev,
        longitude: place.mapx,
        latitude: place.mapy,
        place_name: place.title,
        address: place.address,
      }));
    }
  };
```
`handlePlaceChange` 함수가 받아오는 인수에 `target` 을 추가하여 열리는 장소 검색 모달을 구분하였습니다.
target은 string 타입으로, 출발 지점을 나타내는 from_place_name과, 도착 지점을 나타내는 place_name 두 가지로 구분됩니다!

### 3️⃣ 소요시간 및 출발시간 표시, 폴리라인 구현
<img width="400" alt="Screenshot 2025-04-24 at 10 43 04 am" src="https://github.com/user-attachments/assets/f3f237d6-f083-48c2-acbf-994cf8dae2a1" />

원래 피그마 화면구성에서는 이동방식과 소요시간이 표시되었는데, 네이버 API에서 이동방식을 자동차만 제공하고 있기 때문에 `소요시간`으로 변경하였습니다. 또한 `추천 출발시각`도 같이 표시되도록 하였습니다.

출발위치와 도착위치가 모두 있는 경우에는 지도에 푸른색 라인으로 경로(폴리라인) 표시가 됩니다. 도착위치만 저장된 경우 지도에 도착위치만 표시되며, 위치가 둘 다 없는 경우와 출발위치만 있는 경우는 Next moves탭에 표시되지 않습니다.

현재 아래와 같은 코드로 지도에 라인을 표시해주고 있습니다.
```tsx
new naver.maps.Polyline({
          map: mapRef.current,
          path,
          strokeColor: 'oklch(0.6 0.214963 270.5418)',
          strokeWeight: 4,
        });
```

### 4️⃣ 리액트 쿼리 훅 생성 및 변경
백엔드에서 경로 좌표 데이터를 받아오는 `useGetPathQuery` 훅을 생성하였습니다.
```tsx
const useGetPathQuery = (taskId: number, enabled: boolean) => {
  return useQuery({
    queryKey: [taskId],
    queryFn: () => {
      return getTaskPath(taskId);
    },
    enabled,
  });
};
```
`enabled` 를 사용하여 출발, 도착 위치가 둘 다 있는 경우에만 쿼리가 호출되도록 하였습니다.

또한 일정 수정 시 지도가 다시 받아와지도록 하기 위해 `useEditTaskMutation`에 taskId를 같이 넘겨주어 해당 키를 기반으로 쿼리 무효화를 진행하도록 하였습니다.
```tsx
const useEditTaskMutation = (
  type: 'day' | 'week' | 'month',
  taskId: number | undefined,
) => {
...
```

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
