### PR TITLE
feat: 월간 일정 페이지 모바일 UI 구현

### DIFF
--- a/src/app/(afterlogin)/calendar/monthly/page.tsx
+++ b/src/app/(afterlogin)/calendar/monthly/page.tsx
@@ -50,9 +50,9 @@ export default function Monthly() {
   }, [taskList]);
 
   return (
-    <div className='text-secondary-500 inline-flex h-full min-h-screen w-full bg-[#FAFAFA]'>
+    <div className='text-secondary-500 flex flex-col sm:inline-flex sm:flex-row h-full min-h-screen w-full bg-[#FAFAFA]'>
       <Navigation />
-      <div className='bg-primary-0 h-full w-full min-w-[752px]'>
+      <div className='bg-primary-0 h-full w-full sm:min-w-[752px]'>
         <div className='flex flex-col'>
           <BoardTitle title='일정 관리'>
             <CalendarType />
@@ -62,7 +62,7 @@ export default function Monthly() {
             />
           </BoardTitle>
           <CalendarContainer type='month'>
-            <div className='h-[937px]'>
+            <div className='h-[937px] min-w-[400px]'>
               <Calendar
                 localizer={localizer}
                 defaultDate={new Date()}

--- a/src/app/_components/common/NormalInput.tsx
+++ b/src/app/_components/common/NormalInput.tsx
@@ -19,7 +19,7 @@ function NormalInput({
       {children}
       <input
         {...rest}
-        className='flex-1 outline-none read-only:cursor-default'
+        className='w-full flex-1 outline-none read-only:cursor-default'
       />
     </div>
   );

--- a/src/app/_components/common/SubmitButton.tsx
+++ b/src/app/_components/common/SubmitButton.tsx
@@ -9,7 +9,7 @@ function SubmitButton({ children, className = '', ...rest }: ButtonProps) {
   return (
     <button
       {...rest}
-      className={`${className} text-primary-0 bg-primary-500 cursor-pointer rounded-xl px-[120px] py-[12px] text-[22px] font-bold disabled:cursor-default disabled:opacity-40`}
+      className={`${className} text-primary-0 bg-primary-500 cursor-pointer rounded-xl py-[12px] text-[18px] font-bold disabled:cursor-default disabled:opacity-40 sm:text-[22px]`}
     >
       {children}
     </button>

--- a/src/app/_components/nav/Navigation.tsx
+++ b/src/app/_components/nav/Navigation.tsx
@@ -65,7 +65,7 @@ function Navigation() {
             className='bg-secondary-400 fixed inset-0 opacity-30 sm:hidden'
             onClick={() => setIsOpen(false)}
           />
-          <div className='bg-primary-0 absolute top-[86px] w-full px-[20px] py-[18px] shadow-md sm:hidden'>
+          <div className='bg-primary-0 absolute top-[86px] w-full px-[20px] py-[18px] z-10 shadow-md sm:hidden'>
             <ul className='text-secondary-300 flex flex-col gap-y-[12px]'>
               {navItems.map(navItem => (
                 <Link

--- a/src/app/_components/tasks/DayPickerModal.tsx
+++ b/src/app/_components/tasks/DayPickerModal.tsx
@@ -70,7 +70,7 @@ function DayPickerModal({ closeModal, onChange, value }: DayPickerProps) {
   return (
     <div
       ref={pickerRef}
-      className='bg-primary-0 absolute z-999 mt-[46px] flex gap-[10px] rounded-[10px] p-2.5 shadow-lg'
+      className='bg-primary-0 absolute z-999 mt-[46px] flex flex-col gap-[10px] rounded-[10px] p-2.5 shadow-lg sm:flex-row'
     >
       <DayPicker
         required

--- a/src/app/_components/tasks/LocationModal.tsx
+++ b/src/app/_components/tasks/LocationModal.tsx
@@ -62,7 +62,7 @@ function LocationModal({ closeModal, setPlace }: LocationModalProps) {
   return (
     <div
       ref={locationRef}
-      className='bg-primary-0 absolute top-1/2 left-1/2 z-10 w-[550px] -translate-x-1/2 -translate-y-1/2 transform rounded-[10px] p-2.5 px-[40px] py-[30px] shadow-[0_0_30px_0_rgba(84,87,122,0.7)]'
+      className='bg-primary-0 absolute top-1/2 left-1/2 z-10 min-w-[400px] w-[140%] sm:w-[550px] -translate-x-1/2 -translate-y-1/2 transform rounded-[10px] p-2.5 px-[40px] py-[30px] shadow-[0_0_30px_0_rgba(84,87,122,0.7)]'
     >
       <div className='mb-[30px] flex justify-between'>
         <p className='text-[24px] font-semibold'>장소 검색</p>

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -368,7 +368,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
               <NormalTextarea
                 className='text-[14px] sm:text-[16px]'
                 placeholder='메모'
-                value={value.memo}
+                value={value.memo || ''}
                 onChange={e => handleFieldChange('memo', e)}
               />
             </fieldset>

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -102,7 +102,7 @@ const renderDate = (start: Date, end: Date) => {
   const endTime = format(end, 'hh:mm a');
 
   return (
-    <span className='whitespace-nowrap'>
+    <span>
       <strong>{startDate}</strong> {startTime} ~ <strong>{endDate}</strong>{' '}
       {endTime}
     </span>
@@ -123,7 +123,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
     task ? normalizeTaskDate(task) : initialTask,
   );
   const BASE_STYLE =
-    'flex gap-[20px] *:first:text-xl *:first:font-semibold *:last:flex-1';
+    'flex gap-[20px] *:first:text-[16px] sm\*:first:text-xl *:first:font-semibold *:last:flex-1';
 
   const { mutate: addTaskMutate } = useAddTaskMutation(type);
   const { mutate: editTaskMutate } = useEditTaskMutation(type, task?.task_id);
@@ -219,7 +219,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
   return (
     isOpen && (
       <div className='fixed inset-0 z-50 flex h-dvh w-dvw items-center justify-center bg-[rgba(84,87,122,0.3)]'>
-        <div className='bg-primary-0 w-[708px] rounded-[10px] px-[40px] py-[30px] shadow-[0_0_30px_0_rgba(84,87,122,0.7)] *:w-full'>
+        <div className='bg-primary-0 w-[80%] min-w-[430px] rounded-[10px] px-[40px] py-[30px] shadow-[0_0_30px_0_rgba(84,87,122,0.7)] *:w-full sm:w-[708px]'>
           <div className='mb-[30px] flex justify-between'>
             <p className='text-3xl font-semibold'>{modalMode[mode].title}</p>
             <button
@@ -241,6 +241,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
               <div className='flex flex-col gap-[5px]'>
                 <NormalInput
                   placeholder='제목'
+                  className='text-[14px] sm:text-[16px]'
                   isError={isInvalidTitle}
                   value={value.title}
                   onChange={e => handleFieldChange('title', e)}
@@ -257,16 +258,19 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
               className={`items-center ${BASE_STYLE}`}
               onClick={() => setOpenModal({ type: 'dayPicker' })}
             >
-              <label htmlFor='date'>날짜</label>
+              <label htmlFor='date' className='whitespace-nowrap'>
+                날짜
+              </label>
               <div className='flex flex-col gap-[5px]'>
                 <NormalInput
                   readOnly
-                  className='*:last:hidden'
+                  className='text-[14px] *:last:hidden sm:text-[16px]'
                   isError={isInvalidDate}
                 >
                   <Image
                     src='/assets/calendar-light.png'
                     alt='calendar icon'
+                    className='shrink-0 object-contain'
                     width={24}
                     height={24}
                   />
@@ -290,12 +294,14 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
               </div>
             </fieldset>
             <fieldset className={`relative items-center ${BASE_STYLE}`}>
-              <label htmlFor='location'>출발</label>
+              <label htmlFor='location' className='whitespace-nowrap'>
+                출발
+              </label>
               <div className='flex flex-grow justify-between'>
                 <NormalInput
                   placeholder='출발 위치'
                   value={value.from_place_name || ''}
-                  className='mr-[10px] flex-grow'
+                  className='mr-[10px] flex-grow text-[14px] sm:text-[16px]'
                   onChange={e => handleFieldChange('from_place_name', e)}
                 >
                   <Image
@@ -307,7 +313,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
                 </NormalInput>
                 <SubmitButton
                   type='button'
-                  className='pr-[14px] pl-[14px] font-semibold'
+                  className='pr-[14px] pl-[14px] font-semibold whitespace-nowrap'
                   onClick={() =>
                     setOpenModal({
                       type: 'location',
@@ -320,12 +326,14 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
               </div>
             </fieldset>
             <fieldset className={`relative items-center ${BASE_STYLE}`}>
-              <label htmlFor='location'>도착</label>
+              <label htmlFor='location' className='whitespace-nowrap'>
+                도착
+              </label>
               <div className='flex flex-grow justify-between'>
                 <NormalInput
                   placeholder='도착 위치'
                   value={value.place_name || ''}
-                  className='mr-[10px] flex-grow'
+                  className='mr-[10px] flex-grow text-[14px] sm:text-[16px]'
                   onChange={e => handleFieldChange('place_name', e)}
                 >
                   <Image
@@ -337,7 +345,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
                 </NormalInput>
                 <SubmitButton
                   type='button'
-                  className='pr-[14px] pl-[14px] font-semibold'
+                  className='pr-[14px] pl-[14px] font-semibold whitespace-nowrap'
                   onClick={() =>
                     setOpenModal({
                       type: 'location',
@@ -358,6 +366,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
             <fieldset className={`*:first:mt-2 ${BASE_STYLE}`}>
               <label htmlFor='memo'>메모</label>
               <NormalTextarea
+                className='text-[14px] sm:text-[16px]'
                 placeholder='메모'
                 value={value.memo}
                 onChange={e => handleFieldChange('memo', e)}


### PR DESCRIPTION
## 💡 작업 내용

- [x] 월간 일정 페이지 모바일 UI 구현
- [x] 일정 추가/수정, 장소검색 모달 모바일 UI 구현

## 💡 자세한 설명

### 1️⃣ 월간 일정 페이지 모바일 UI 구현
월간 일정 페이지의 모바일뷰를 구현하였습니다.
<img width="400" alt="Screenshot 2025-04-25 at 5 30 33 pm" src="https://github.com/user-attachments/assets/e16d66ac-1310-4958-b2a1-4876ffb8279c" />

### 2️⃣ 일정 추가/수정 모달, 장소검색 모달 모바일 UI 구현
일정 추가/수정 모달과 장소검색 모달의 모바일 UI도 구현해두었습니다. `datepicker` 부분은 크게 바꾸지 않고, flex 방향만 세로로 설정해 두었습니다.
| 일정 추가 | 일정 삭제 |
| --- | --- |
| <img width="460" alt="Screenshot 2025-04-25 at 5 30 42 pm" src="https://github.com/user-attachments/assets/041e838d-ca20-489c-a8b5-e6d8217ba0eb" /> | <img width="466" alt="Screenshot 2025-04-25 at 5 30 56 pm" src="https://github.com/user-attachments/assets/38f01e98-a524-4e54-bb8e-4d88374428c9" /> |

| 장소 검색 | datepicker |
| --- | --- |
| <img width="490" alt="Screenshot 2025-04-25 at 5 33 06 pm" src="https://github.com/user-attachments/assets/67ac71cc-c535-49e3-a045-062dc5b2ef60" /> | <img width="475" alt="Screenshot 2025-04-25 at 5 34 16 pm" src="https://github.com/user-attachments/assets/a491b670-ad7a-427a-9b86-3fb0e06d613f" /> |

### 3️⃣ 기타 사항
textarea부분이 null 값인 경우 자꾸 `'value' prop on 'textarea' should not be null. Consider using an empty string to clear the component or 'undefined' for uncontrolled components.` 오류가 발생하여 빈 문자열로 처리하였습니다.
```tsx
<NormalTextarea
                className='text-[14px] sm:text-[16px]'
                placeholder='메모'
                value={value.memo || ''}
                onChange={e => handleFieldChange('memo', e)}
              />
```

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
