### PR TITLE
feat: 날씨 API 연동 및 날씨 페이지 모바일 반응형 구현

### DIFF
--- a/src/app/(afterlogin)/weather/CurrentIndex.tsx
+++ b/src/app/(afterlogin)/weather/CurrentIndex.tsx
@@ -39,17 +39,17 @@ function CurrentIndex({ type, value, subValue }: CurrentIndexProps) {
   return (
     <div className='bg-primary-0 border-primary-200 inline-flex flex-col gap-[10px] rounded-2xl border px-[30px] py-[26px]'>
       <div className='flex items-center gap-[5px]'>
-        <Image
-          src={indexType[type].imageUrl}
-          alt={`${type} 이미지`}
-          width={20}
-          height={20}
-        />
-        <p className='text-primary-400 text-[18px] font-semibold'>{type}</p>
+        <div className='relative h-[16px] w-[16px] sm:h-[20px] sm:w-[20px]'>
+          <Image src={indexType[type].imageUrl} alt={`${type} 이미지`} fill />
+        </div>
+
+        <p className='text-primary-400 text-[14px] font-semibold sm:text-[18px]'>
+          {type}
+        </p>
       </div>
       <div className='text-secondary-400 flex items-baseline font-medium'>
-        <p className='text-[34px]'>{value}</p>
-        {subValue && <p className='text-[20px]'>{subValue}</p>}
+        <p className='text-[22px] sm:text-[34px]'>{value}</p>
+        {subValue && <p className='text-[14px] sm:text-[20px]'>{subValue}</p>}
       </div>
     </div>
   );

--- a/src/app/(afterlogin)/weather/CurrentIndex.tsx
+++ b/src/app/(afterlogin)/weather/CurrentIndex.tsx
@@ -1,36 +1,9 @@
+import { IndexNameType } from '@/app/_types/weather';
 import Image from 'next/image';
-
-type IndexType =
-  | '미세먼지'
-  | '초미세먼지'
-  | '자외선'
-  | '습도'
-  | '바람'
-  | '기압';
-
-const indexType: Record<IndexType, { imageUrl: string }> = {
-  미세먼지: {
-    imageUrl: '/assets/weather/index/bubble-index.png',
-  },
-  초미세먼지: {
-    imageUrl: '/assets/weather/index/bubble-index.png',
-  },
-  자외선: {
-    imageUrl: '/assets/weather/index/sun-uv-index.png',
-  },
-  습도: {
-    imageUrl: '/assets/weather/index/drop-index.png',
-  },
-  바람: {
-    imageUrl: '/assets/weather/index/wind-index.png',
-  },
-  기압: {
-    imageUrl: '/assets/weather/index/speedometer.png',
-  },
-};
+import { indexType } from './_constant/currentIndex';
 
 interface CurrentIndexProps {
-  type: IndexType;
+  type: IndexNameType;
   value: number;
   subValue?: string;
 }

--- a/src/app/(afterlogin)/weather/CurrentIndex.tsx
+++ b/src/app/(afterlogin)/weather/CurrentIndex.tsx
@@ -31,7 +31,7 @@ const indexType: Record<IndexType, { imageUrl: string }> = {
 
 interface CurrentIndexProps {
   type: IndexType;
-  value: string;
+  value: number;
   subValue?: string;
 }
 

--- a/src/app/(afterlogin)/weather/CurrentWeather.tsx
+++ b/src/app/(afterlogin)/weather/CurrentWeather.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
-import { WeatherInfo } from './weatherCode';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
+import { WeatherInfo } from './_constant/weatherCode';
 
 interface CurrentWeatherProps {
   location: string;

--- a/src/app/(afterlogin)/weather/CurrentWeather.tsx
+++ b/src/app/(afterlogin)/weather/CurrentWeather.tsx
@@ -1,5 +1,7 @@
 import Image from 'next/image';
 import { WeatherInfo } from './weatherCode';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
 
 interface CurrentWeatherProps {
   location: string;
@@ -16,28 +18,47 @@ function CurrentWeather({
 }: CurrentWeatherProps) {
   return (
     <div className='border-primary-200 bg-primary-0 flex flex-col gap-[10px] rounded-2xl border px-[30px] py-[26px]'>
-      <div className='flex justify-between'>
+      <div className='flex items-start justify-between'>
         <div className='flex items-center gap-[5px]'>
-          <Image
-            src='/assets/location-big.png'
-            alt='위치 아이콘 이미지'
-            width={20}
-            height={20}
-          />
-          <p className='text-primary-400 text-lg font-normal'>{location}</p>
+          <div className='relative h-[18px] w-[18px] sm:h-[20px] sm:w-[20px]'>
+            <Image
+              src='/assets/location-big.png'
+              alt='위치 아이콘 이미지'
+              fill
+            />
+          </div>
+          <p className='text-primary-400 text-[14px] font-normal text-nowrap sm:text-lg'>
+            {location}
+          </p>
         </div>
-        <p className='text-secondary-400 text-2xl font-medium'>{currentTime}</p>
+        <div className='text-secondary-400 flex flex-col items-end text-[14px] font-medium text-nowrap sm:flex-row sm:gap-[10px] sm:text-2xl'>
+          <p>
+            {format(currentTime, 'M월 d일(eee)', {
+              locale: ko,
+            })}
+          </p>
+          <p>
+            {format(currentTime, ' a h:mm', {
+              locale: ko,
+            })}
+          </p>
+        </div>
       </div>
       <div className='flex items-center gap-[15px]'>
-        <Image
-          src={weatherInfo.imageUrl}
-          alt={`${weatherInfo.codeName} 이미지`}
-          width={96}
-          height={96}
-        />
+        <div className='relative h-[76px] w-[76px] sm:h-[96px] sm:w-[96px]'>
+          <Image
+            src={weatherInfo.imageUrl}
+            alt={`${weatherInfo.codeName} 이미지`}
+            fill
+          />
+        </div>
         <div className='text-secondary-400'>
-          <p className='text-[40px] font-medium'>{temperature}</p>
-          <p className='text-[20px] font-normal'>{weatherInfo.codeName}</p>
+          <p className='text-[30px] font-medium sm:text-[40px]'>
+            {temperature}
+          </p>
+          <p className='text-[16px] font-normal sm:text-[20px]'>
+            {weatherInfo.codeName}
+          </p>
         </div>
       </div>
     </div>

--- a/src/app/(afterlogin)/weather/HourlyWeather.tsx
+++ b/src/app/(afterlogin)/weather/HourlyWeather.tsx
@@ -17,16 +17,20 @@ function HourlyWeather({
   const parseTime = (timeStr: string) => {
     const match = timeStr.match(/^(\d{1,2})(AM|PM)$/i);
     if (!match) {
-      return <p className='text-[16px] font-medium'>{timeStr}</p>;
+      return (
+        <p className='text-[12px] font-medium sm:text-[16px]'>{timeStr}</p>
+      );
     }
 
     const hour = parseInt(match[1], 10);
     const period = match[2].toUpperCase() as 'AM' | 'PM';
 
     return (
-      <div className='flex items-baseline'>
-        <p className='text-[16px] font-medium'>{hour}</p>
-        {period && <p className='text-[12px] font-normal'>{period}</p>}
+      <div className='flex items-baseline justify-center'>
+        <p className='text-[12px] font-medium sm:text-[16px]'>{hour}</p>
+        {period && (
+          <p className='text-[8px] font-normal sm:text-[12px]'>{period}</p>
+        )}
       </div>
     );
   };
@@ -41,16 +45,22 @@ function HourlyWeather({
           width={36}
           height={36}
         />
-        <p className='text-[20px] font-semibold'>{temperature}</p>
+        <p className='text-[16px] font-semibold sm:text-[20px]'>
+          {temperature}
+        </p>
       </div>
-      <div className='flex items-center'>
-        <Image
-          src='/assets/weather/drop.png'
-          alt='강수량 물방울 이미지'
-          width={14}
-          height={14}
-        />
-        <p className='text-secondary-300 text-sm font-semibold'>{rainfall}</p>
+      <div className='flex w-full items-center justify-around gap-[2px]'>
+        <div className='relative h-[10px] w-[10px] sm:h-[14px] sm:w-[14px]'>
+          <Image
+            src='/assets/weather/drop.png'
+            alt='강수량 물방울 이미지'
+            fill
+          />
+        </div>
+
+        <p className='text-secondary-300 text-sm text-[10px] font-semibold sm:text-[14px]'>
+          {rainfall}
+        </p>
       </div>
     </div>
   );

--- a/src/app/(afterlogin)/weather/HourlyWeather.tsx
+++ b/src/app/(afterlogin)/weather/HourlyWeather.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { WeatherInfo } from './weatherCode';
+import { WeatherInfo } from './_constant/weatherCode';
 
 interface HourlyWeatherProps {
   time: string;

--- a/src/app/(afterlogin)/weather/RecommendDress.tsx
+++ b/src/app/(afterlogin)/weather/RecommendDress.tsx
@@ -14,7 +14,7 @@ function RecommendDress() {
           옷차림 추천
         </p>
       </div>
-      <p className='flex h-full items-center justify-center'>
+      <p className='flex h-full items-center justify-center py-[15px] text-[12px] sm:text-[16px]'>
         서비스 준비 중입니다.
       </p>
     </div>

--- a/src/app/(afterlogin)/weather/WeeklyContainer.tsx
+++ b/src/app/(afterlogin)/weather/WeeklyContainer.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+
+interface WeeklyContainerProps {
+  children: ReactNode;
+}
+
+function WeeklyContainer({ children }: WeeklyContainerProps) {
+  return (
+    <div className='border-primary-200 bg-primary-0 flex flex-col items-center justify-center gap-[16px] rounded-2xl border px-[30px] py-[26px]'>
+      {children}
+    </div>
+  );
+}
+
+export default WeeklyContainer;

--- a/src/app/(afterlogin)/weather/WeeklyWeather.tsx
+++ b/src/app/(afterlogin)/weather/WeeklyWeather.tsx
@@ -1,7 +1,36 @@
-function WeeklyWeather() {
+import Image from 'next/image';
+
+import { WeeklyWeatherType } from '@/app/_types/weather';
+import { getWeatherInfo } from './weatherCode';
+import { format } from 'date-fns';
+
+interface WeeklyWeatherProps {
+  data: WeeklyWeatherType;
+}
+
+function WeeklyWeather({ data }: WeeklyWeatherProps) {
+  const weatherInfo = getWeatherInfo(data.weathercode);
+
   return (
-    <div className='border-primary-200 bg-primary-0 flex h-full flex-col items-center justify-center rounded-2xl border px-[30px] py-[26px]'>
-      서비스 준비 중입니다.
+    <div className='text-secondary-400 flex w-full items-center text-[16px] font-medium'>
+      <p className='flex-1'>{format(data.date, 'EEE')}</p>
+      <div className='flex items-center gap-[20px]'>
+        <Image
+          src='/assets/weather/drop.png'
+          alt='강수량 물방울 이미지'
+          width={14}
+          height={14}
+        />
+        <p className='text-secondary-300 text-centers min-w-[40px]'>{`${data.precipitationProbability}%`}</p>
+        <Image
+          src={weatherInfo.imageUrl}
+          alt={`${weatherInfo.codeName} image`}
+          width={36}
+          height={36}
+        />
+        <p className='min-w-[44px] text-center'>{`${data.tempMax}°`}</p>
+        <p className='min-w-[44px] text-center'>{`${data.tempMin}°`}</p>
+      </div>
     </div>
   );
 }

--- a/src/app/(afterlogin)/weather/WeeklyWeather.tsx
+++ b/src/app/(afterlogin)/weather/WeeklyWeather.tsx
@@ -12,24 +12,24 @@ function WeeklyWeather({ data }: WeeklyWeatherProps) {
   const weatherInfo = getWeatherInfo(data.weathercode);
 
   return (
-    <div className='text-secondary-400 flex w-full items-center text-[16px] font-medium'>
+    <div className='text-secondary-400 flex w-full items-center text-[12px] font-medium sm:text-[16px]'>
       <p className='flex-1'>{format(data.date, 'EEE')}</p>
-      <div className='flex items-center gap-[20px]'>
+      <div className='flex items-center gap-[12px] sm:gap-[20px]'>
         <Image
           src='/assets/weather/drop.png'
           alt='강수량 물방울 이미지'
           width={14}
           height={14}
         />
-        <p className='text-secondary-300 text-centers min-w-[40px]'>{`${data.precipitationProbability}%`}</p>
+        <p className='text-secondary-300 text-centers min-w-[28px] sm:min-w-[40px]'>{`${data.precipitationProbability}%`}</p>
         <Image
           src={weatherInfo.imageUrl}
           alt={`${weatherInfo.codeName} image`}
           width={36}
           height={36}
         />
-        <p className='min-w-[44px] text-center'>{`${data.tempMax}°`}</p>
-        <p className='min-w-[44px] text-center'>{`${data.tempMin}°`}</p>
+        <p className='min-w-[34px] text-center sm:min-w-[44px]'>{`${data.tempMax}°`}</p>
+        <p className='min-w-[34px] text-center sm:min-w-[44px]'>{`${data.tempMin}°`}</p>
       </div>
     </div>
   );

--- a/src/app/(afterlogin)/weather/WeeklyWeather.tsx
+++ b/src/app/(afterlogin)/weather/WeeklyWeather.tsx
@@ -1,8 +1,7 @@
 import Image from 'next/image';
-
 import { WeeklyWeatherType } from '@/app/_types/weather';
-import { getWeatherInfo } from './weatherCode';
 import { format } from 'date-fns';
+import { getWeatherInfo } from '@/app/_utils/getWeatherInfo';
 
 interface WeeklyWeatherProps {
   data: WeeklyWeatherType;

--- a/src/app/(afterlogin)/weather/_constant/currentIndex.ts
+++ b/src/app/(afterlogin)/weather/_constant/currentIndex.ts
@@ -1,0 +1,68 @@
+import { IndexNameType, IndexType } from '@/app/_types/weather';
+
+type CurrentIndexType = {
+  id: number;
+  type: keyof IndexType;
+  typeName: IndexNameType;
+  unit: string;
+};
+
+export const currentIndex: CurrentIndexType[] = [
+  {
+    id: 1,
+    type: 'pm10',
+    typeName: '미세먼지',
+    unit: 'µg/m³',
+  },
+  {
+    id: 2,
+    type: 'pm2_5',
+    typeName: '초미세먼지',
+    unit: 'µg/m³',
+  },
+  {
+    id: 3,
+    type: 'uv_index',
+    typeName: '자외선',
+    unit: '',
+  },
+  {
+    id: 4,
+    type: 'humidity',
+    typeName: '습도',
+    unit: '%',
+  },
+  {
+    id: 5,
+    type: 'windspeed',
+    typeName: '바람',
+    unit: 'm/s',
+  },
+  {
+    id: 6,
+    type: 'pressure',
+    typeName: '기압',
+    unit: 'hPa',
+  },
+];
+
+export const indexType: Record<IndexNameType, { imageUrl: string }> = {
+  미세먼지: {
+    imageUrl: '/assets/weather/index/bubble-index.png',
+  },
+  초미세먼지: {
+    imageUrl: '/assets/weather/index/bubble-index.png',
+  },
+  자외선: {
+    imageUrl: '/assets/weather/index/sun-uv-index.png',
+  },
+  습도: {
+    imageUrl: '/assets/weather/index/drop-index.png',
+  },
+  바람: {
+    imageUrl: '/assets/weather/index/wind-index.png',
+  },
+  기압: {
+    imageUrl: '/assets/weather/index/speedometer.png',
+  },
+};

--- a/src/app/(afterlogin)/weather/_constant/weatherCode.ts
+++ b/src/app/(afterlogin)/weather/_constant/weatherCode.ts
@@ -52,21 +52,3 @@ export const weatherCode: Record<WeatherType, WeatherInfo> = {
     imageUrl: '/assets/weather/hail.png',
   },
 };
-
-export const getWeatherInfo = (code: number) => {
-  if (code === 0) return weatherCode.clear;
-  if (code === 1 || code === 2) return weatherCode.partlyCloudy;
-  if (code === 3) return weatherCode.overcast;
-  if (code === 45 || code === 48) return weatherCode.fog;
-  if (code >= 51 && code <= 57) return weatherCode.drizzle;
-  if (code >= 61 && code <= 67) return weatherCode.rain;
-  if (code >= 71 && code <= 77) return weatherCode.snow;
-  if (code >= 80 && code <= 82) return weatherCode.rain;
-  if (code === 95) return weatherCode.thunderstorm;
-  if (code >= 96 && code <= 99) return weatherCode.hail;
-
-  return {
-    codeName: '알 수 없음',
-    imageUrl: '/assets/weather/unknown.png',
-  };
-};

--- a/src/app/(afterlogin)/weather/page.tsx
+++ b/src/app/(afterlogin)/weather/page.tsx
@@ -8,11 +8,12 @@ import CurrentWeather from './CurrentWeather';
 import WeeklyWeather from './WeeklyWeather';
 import RecommendDress from './RecommendDress';
 import HourlyContainer from './HourlyContainer';
-import { getWeatherInfo } from './weatherCode';
 import useGetWeatherQuery from '@/app/_hooks/useGetWeatherQuery';
 import { format } from 'date-fns';
 import useGetLocationName from '@/app/_hooks/useGetLocationName';
 import WeeklyContainer from './WeeklyContainer';
+import { currentIndex } from './_constant/currentIndex';
+import { getWeatherInfo } from '@/app/_utils/getWeatherInfo';
 
 export default function Weather() {
   const { data: weatherData, isPending } = useGetWeatherQuery();
@@ -58,36 +59,14 @@ export default function Weather() {
               </HourlyContainer>
             </section>
             <section className='grid grid-cols-2 gap-[16px] sm:grid-cols-3 sm:gap-[30px]'>
-              <CurrentIndex
-                type='미세먼지'
-                value={currentData.pm10}
-                subValue='µg/m³'
-              />
-              <CurrentIndex
-                type='초미세먼지'
-                value={currentData.pm2_5}
-                subValue='µg/m³'
-              />
-              <CurrentIndex
-                type='자외선'
-                value={currentData.uv_index}
-                subValue=''
-              />
-              <CurrentIndex
-                type='습도'
-                value={currentData.humidity}
-                subValue='%'
-              />
-              <CurrentIndex
-                type='바람'
-                value={currentData.windspeed}
-                subValue='m/s'
-              />
-              <CurrentIndex
-                type='기압'
-                value={currentData.pressure}
-                subValue='hPa'
-              />
+              {currentIndex.map(({ id, type, typeName, unit }) => (
+                <CurrentIndex
+                  key={id}
+                  type={typeName}
+                  value={currentData[type]}
+                  subValue={unit}
+                />
+              ))}
             </section>
           </div>
           <div className='flex flex-col gap-[23px] sm:w-[40%]'>

--- a/src/app/(afterlogin)/weather/page.tsx
+++ b/src/app/(afterlogin)/weather/page.tsx
@@ -12,6 +12,8 @@ import { getWeatherInfo } from './weatherCode';
 import useGetWeatherQuery from '@/app/_hooks/useGetWeatherQuery';
 import { format } from 'date-fns';
 import useGetLocationName from '@/app/_hooks/useGetLocationName';
+import WeeklyContainer from './WeeklyContainer';
+import { ko } from 'date-fns/locale';
 
 export default function Weather() {
   const { data: weatherData, isPending } = useGetWeatherQuery();
@@ -23,6 +25,7 @@ export default function Weather() {
 
   const currentData = weatherData.current;
   const hourlyData = weatherData.hourly;
+  const weeklyData = weatherData.daily;
 
   return (
     <div className='text-secondary-500 inline-flex h-full min-h-screen w-full bg-[#FAFAFA]'>
@@ -31,68 +34,78 @@ export default function Weather() {
         <div className='bg-primary-0 flex flex-col'>
           <BoardTitle title='날씨'></BoardTitle>
         </div>
-        <main className='grid grid-cols-5 gap-x-[50px] gap-y-[23px] p-[32px]'>
-          <section className='col-span-3 flex max-w-[1000px] flex-col gap-[15px]'>
-            <p className='text-[24px] font-semibold'>현재</p>
-            <CurrentWeather
-              location={locationName}
-              currentTime={format(currentData.time, 'h:mm a')}
-              temperature={`${currentData?.temperature}°`}
-              weatherInfo={getWeatherInfo(currentData.weathercode)}
-            />
-            <HourlyContainer>
-              {hourlyData.map(
-                ({ time, temperature, precipitation, weathercode }) => (
-                  <HourlyWeather
-                    key={time}
-                    time={format(time, 'ha')}
-                    temperature={`${temperature}°`}
-                    rainfall={`${precipitation}%`}
-                    weatherInfo={getWeatherInfo(weathercode)}
-                  />
-                ),
-              )}
-            </HourlyContainer>
-          </section>
-          <section className='col-span-2 flex h-full flex-col gap-[15px]'>
-            <p className='text-[24px] font-semibold'>주간 날씨</p>
-            <WeeklyWeather />
-          </section>
-          <section className='col-span-3 grid grid-cols-3 gap-[30px]'>
-            <CurrentIndex
-              type='미세먼지'
-              value={currentData.pm10}
-              subValue='µg/m³'
-            />
-            <CurrentIndex
-              type='초미세먼지'
-              value={currentData.pm2_5}
-              subValue='µg/m³'
-            />
-            <CurrentIndex
-              type='자외선'
-              value={currentData.uv_index}
-              subValue=''
-            />
-            <CurrentIndex
-              type='습도'
-              value={currentData.humidity}
-              subValue='%'
-            />
-            <CurrentIndex
-              type='바람'
-              value={currentData.windspeed}
-              subValue='m/s'
-            />
-            <CurrentIndex
-              type='기압'
-              value={currentData.pressure}
-              subValue='hPa'
-            />
-          </section>
-          <section className='col-span-2'>
-            <RecommendDress />
-          </section>
+        <main className='flex w-full gap-x-[50px] gap-y-[23px] p-[32px]'>
+          <div className='flex w-[60%] flex-col gap-[23px]'>
+            <section className='flex flex-col gap-[15px]'>
+              <p className='text-[24px] font-semibold'>현재</p>
+              <CurrentWeather
+                location={locationName}
+                currentTime={format(currentData.time, 'M월 d일(eee) a h:mm ', {
+                  locale: ko,
+                })}
+                temperature={`${currentData?.temperature}°`}
+                weatherInfo={getWeatherInfo(currentData.weathercode)}
+              />
+              <HourlyContainer>
+                {hourlyData.map(
+                  ({ time, temperature, precipitation, weathercode }) => (
+                    <HourlyWeather
+                      key={time}
+                      time={format(time, 'ha')}
+                      temperature={`${temperature}°`}
+                      rainfall={`${precipitation}%`}
+                      weatherInfo={getWeatherInfo(weathercode)}
+                    />
+                  ),
+                )}
+              </HourlyContainer>
+            </section>
+            <section className='grid grid-cols-3 gap-[30px]'>
+              <CurrentIndex
+                type='미세먼지'
+                value={currentData.pm10}
+                subValue='µg/m³'
+              />
+              <CurrentIndex
+                type='초미세먼지'
+                value={currentData.pm2_5}
+                subValue='µg/m³'
+              />
+              <CurrentIndex
+                type='자외선'
+                value={currentData.uv_index}
+                subValue=''
+              />
+              <CurrentIndex
+                type='습도'
+                value={currentData.humidity}
+                subValue='%'
+              />
+              <CurrentIndex
+                type='바람'
+                value={currentData.windspeed}
+                subValue='m/s'
+              />
+              <CurrentIndex
+                type='기압'
+                value={currentData.pressure}
+                subValue='hPa'
+              />
+            </section>
+          </div>
+          <div className='flex w-[40%] flex-col gap-[23px]'>
+            <section className='flex flex-col gap-[15px]'>
+              <p className='text-[24px] font-semibold'>주간 날씨</p>
+              <WeeklyContainer>
+                {weeklyData.map(data => (
+                  <WeeklyWeather key={data.date} data={data} />
+                ))}
+              </WeeklyContainer>
+            </section>
+            <section className=''>
+              <RecommendDress />
+            </section>
+          </div>
         </main>
       </div>
     </div>

--- a/src/app/(afterlogin)/weather/page.tsx
+++ b/src/app/(afterlogin)/weather/page.tsx
@@ -9,8 +9,19 @@ import WeeklyWeather from './WeeklyWeather';
 import RecommendDress from './RecommendDress';
 import HourlyContainer from './HourlyContainer';
 import { getWeatherInfo } from './weatherCode';
+import useGetWeatherQuery from '@/app/_hooks/useGetWeatherQuery';
+import { format } from 'date-fns';
 
 export default function Weather() {
+  const { data: weatherData, isPending } = useGetWeatherQuery();
+
+  if (!weatherData || isPending) {
+    return;
+  }
+
+  const currentData = weatherData.current;
+  const hourlyData = weatherData.hourly;
+
   return (
     <div className='text-secondary-500 inline-flex h-full min-h-screen w-full bg-[#FAFAFA]'>
       <Navigation />
@@ -22,102 +33,23 @@ export default function Weather() {
           <section className='col-span-3 flex max-w-[1000px] flex-col gap-[15px]'>
             <p className='text-[24px] font-semibold'>현재</p>
             <CurrentWeather
-              location='수원시 영통구'
-              currentTime='9:00 AM'
-              temperature='17°'
-              weatherInfo={getWeatherInfo(0)}
+              location='동네 이름'
+              currentTime={format(currentData.time, 'h:mm a')}
+              temperature={`${currentData?.temperature}°`}
+              weatherInfo={getWeatherInfo(currentData.weathercode)}
             />
             <HourlyContainer>
-              <HourlyWeather
-                time='Now'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(0)}
-              />
-              <HourlyWeather
-                time='10AM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(1)}
-              />
-              <HourlyWeather
-                time='11AM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(3)}
-              />
-              <HourlyWeather
-                time='12AM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(45)}
-              />
-              <HourlyWeather
-                time='1PM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(51)}
-              />
-              <HourlyWeather
-                time='2PM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(61)}
-              />
-              <HourlyWeather
-                time='3PM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(71)}
-              />
-              <HourlyWeather
-                time='4PM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(80)}
-              />
-              <HourlyWeather
-                time='5PM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(95)}
-              />
-              <HourlyWeather
-                time='6PM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(95)}
-              />
-              <HourlyWeather
-                time='7PM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(95)}
-              />
-              <HourlyWeather
-                time='8PM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(95)}
-              />
-              <HourlyWeather
-                time='9PM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(95)}
-              />
-              <HourlyWeather
-                time='10PM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(95)}
-              />
-              <HourlyWeather
-                time='11PM'
-                temperature='17°'
-                rainfall='10%'
-                weatherInfo={getWeatherInfo(95)}
-              />
+              {hourlyData.map(
+                ({ time, temperature, precipitation, weathercode }) => (
+                  <HourlyWeather
+                    key={time}
+                    time={format(time, 'ha')}
+                    temperature={`${temperature}°`}
+                    rainfall={`${precipitation}%`}
+                    weatherInfo={getWeatherInfo(weathercode)}
+                  />
+                ),
+              )}
             </HourlyContainer>
           </section>
           <section className='col-span-2 flex h-full flex-col gap-[15px]'>
@@ -125,12 +57,36 @@ export default function Weather() {
             <WeeklyWeather />
           </section>
           <section className='col-span-3 grid grid-cols-3 gap-[30px]'>
-            <CurrentIndex type='미세먼지' value='43' subValue='(bad)' />
-            <CurrentIndex type='초미세먼지' value='43' subValue='(bad)' />
-            <CurrentIndex type='자외선' value='43' subValue='(bad)' />
-            <CurrentIndex type='습도' value='43' subValue='(bad)' />
-            <CurrentIndex type='바람' value='43' subValue='(bad)' />
-            <CurrentIndex type='기압' value='43' subValue='(bad)' />
+            <CurrentIndex
+              type='미세먼지'
+              value={currentData.pm10}
+              subValue='µg/m³'
+            />
+            <CurrentIndex
+              type='초미세먼지'
+              value={currentData.pm2_5}
+              subValue='µg/m³'
+            />
+            <CurrentIndex
+              type='자외선'
+              value={currentData.uv_index}
+              subValue=''
+            />
+            <CurrentIndex
+              type='습도'
+              value={currentData.humidity}
+              subValue='%'
+            />
+            <CurrentIndex
+              type='바람'
+              value={currentData.windspeed}
+              subValue='m/s'
+            />
+            <CurrentIndex
+              type='기압'
+              value={currentData.pressure}
+              subValue='hPa'
+            />
           </section>
           <section className='col-span-2'>
             <RecommendDress />

--- a/src/app/(afterlogin)/weather/page.tsx
+++ b/src/app/(afterlogin)/weather/page.tsx
@@ -13,7 +13,6 @@ import useGetWeatherQuery from '@/app/_hooks/useGetWeatherQuery';
 import { format } from 'date-fns';
 import useGetLocationName from '@/app/_hooks/useGetLocationName';
 import WeeklyContainer from './WeeklyContainer';
-import { ko } from 'date-fns/locale';
 
 export default function Weather() {
   const { data: weatherData, isPending } = useGetWeatherQuery();
@@ -28,21 +27,19 @@ export default function Weather() {
   const weeklyData = weatherData.daily;
 
   return (
-    <div className='text-secondary-500 inline-flex h-full min-h-screen w-full bg-[#FAFAFA]'>
+    <div className='text-secondary-500 inline-flex h-full min-h-screen w-full flex-col bg-[#FAFAFA] sm:flex-row'>
       <Navigation />
       <div className='h-full w-full min-w-[752px]'>
         <div className='bg-primary-0 flex flex-col'>
           <BoardTitle title='날씨'></BoardTitle>
         </div>
-        <main className='flex w-full gap-x-[50px] gap-y-[23px] p-[32px]'>
-          <div className='flex w-[60%] flex-col gap-[23px]'>
+        <main className='flex w-dvw min-w-[375px] flex-col gap-x-[50px] gap-y-[23px] p-[32px] sm:w-full sm:flex-row'>
+          <div className='flex flex-col gap-[23px] sm:w-[60%]'>
             <section className='flex flex-col gap-[15px]'>
-              <p className='text-[24px] font-semibold'>현재</p>
+              <p className='text-[22px] font-semibold sm:text-[24px]'>현재</p>
               <CurrentWeather
                 location={locationName}
-                currentTime={format(currentData.time, 'M월 d일(eee) a h:mm ', {
-                  locale: ko,
-                })}
+                currentTime={currentData.time}
                 temperature={`${currentData?.temperature}°`}
                 weatherInfo={getWeatherInfo(currentData.weathercode)}
               />
@@ -60,7 +57,7 @@ export default function Weather() {
                 )}
               </HourlyContainer>
             </section>
-            <section className='grid grid-cols-3 gap-[30px]'>
+            <section className='grid grid-cols-2 gap-[16px] sm:grid-cols-3 sm:gap-[30px]'>
               <CurrentIndex
                 type='미세먼지'
                 value={currentData.pm10}
@@ -93,9 +90,11 @@ export default function Weather() {
               />
             </section>
           </div>
-          <div className='flex w-[40%] flex-col gap-[23px]'>
+          <div className='flex flex-col gap-[23px] sm:w-[40%]'>
             <section className='flex flex-col gap-[15px]'>
-              <p className='text-[24px] font-semibold'>주간 날씨</p>
+              <p className='text-[22px] font-semibold sm:text-[24px]'>
+                주간 날씨
+              </p>
               <WeeklyContainer>
                 {weeklyData.map(data => (
                   <WeeklyWeather key={data.date} data={data} />

--- a/src/app/(afterlogin)/weather/page.tsx
+++ b/src/app/(afterlogin)/weather/page.tsx
@@ -11,9 +11,11 @@ import HourlyContainer from './HourlyContainer';
 import { getWeatherInfo } from './weatherCode';
 import useGetWeatherQuery from '@/app/_hooks/useGetWeatherQuery';
 import { format } from 'date-fns';
+import useGetLocationName from '@/app/_hooks/useGetLocationName';
 
 export default function Weather() {
   const { data: weatherData, isPending } = useGetWeatherQuery();
+  const { locationName } = useGetLocationName();
 
   if (!weatherData || isPending) {
     return;
@@ -33,7 +35,7 @@ export default function Weather() {
           <section className='col-span-3 flex max-w-[1000px] flex-col gap-[15px]'>
             <p className='text-[24px] font-semibold'>현재</p>
             <CurrentWeather
-              location='동네 이름'
+              location={locationName}
               currentTime={format(currentData.time, 'h:mm a')}
               temperature={`${currentData?.temperature}°`}
               weatherInfo={getWeatherInfo(currentData.weathercode)}

--- a/src/app/_apis/weather.ts
+++ b/src/app/_apis/weather.ts
@@ -1,0 +1,10 @@
+import { GeoLocation } from '../_types/location';
+import { api } from './tasks';
+
+export const getWeather = async (location: GeoLocation) => {
+  const params = new URLSearchParams();
+  params.set('lat', location.latitude.toString());
+  params.set('lon', location.longitude.toString());
+
+  return await api.get(`/weather?${params}`);
+};

--- a/src/app/_hooks/useCurrentLocation.ts
+++ b/src/app/_hooks/useCurrentLocation.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { GeoLocation } from '../_types/location';
+
+const useCurrentLocation = () => {
+  const [location, setLocation] = useState<GeoLocation | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!navigator.geolocation) {
+      setError('Geolocation을 지원하지 않는 브라우저입니다.');
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      position => {
+        setLocation({
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+        });
+      },
+      err => {
+        setError(err.message);
+      },
+    );
+  }, []);
+
+  return { location, error };
+};
+
+export default useCurrentLocation;

--- a/src/app/_hooks/useGetLocationName.ts
+++ b/src/app/_hooks/useGetLocationName.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import useCurrentLocation from './useCurrentLocation';
+
+const useGetLocationName = () => {
+  const [locationName, setLocationName] = useState('');
+  const { location } = useCurrentLocation();
+
+  useEffect(() => {
+    if (window.naver && window.naver.maps && location) {
+      naver.maps.Service.reverseGeocode(
+        {
+          coords: new naver.maps.LatLng(location.latitude, location.longitude),
+        },
+        (status, response) => {
+          if (status !== naver.maps.Service.Status.OK) {
+            return setLocationName('현재 위치를 불러올 수 없습니다.');
+          }
+
+          const result = response.v2;
+          const regions = result.results[1].region;
+          setLocationName(`${regions.area1.name} ${regions.area2.name}`);
+        },
+      );
+    }
+  }, [location]);
+
+  return { locationName };
+};
+
+export default useGetLocationName;

--- a/src/app/_hooks/useGetWeatherQuery.ts
+++ b/src/app/_hooks/useGetWeatherQuery.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import useCurrentLocation from './useCurrentLocation';
+import { getWeather } from '../_apis/weather';
+import { AxiosError, AxiosResponse } from 'axios';
+import { WeatherResponse } from '../_types/weather';
+
+const useGetWeatherQuery = () => {
+  const { location, error } = useCurrentLocation();
+
+  return useQuery<AxiosResponse<WeatherResponse>, AxiosError, WeatherResponse>({
+    queryKey: ['weather', location],
+    queryFn: () => {
+      if (!location) {
+        throw new Error(error ?? '위치 정보를 가져올 수 없습니다.');
+      }
+
+      return getWeather(location);
+    },
+    enabled: !!location,
+    select: data => data.data,
+  });
+};
+
+export default useGetWeatherQuery;

--- a/src/app/_types/location.ts
+++ b/src/app/_types/location.ts
@@ -18,3 +18,7 @@ export interface GeoSearchResult extends LocationResult {
   mapy: number;
 }
 
+export interface GeoLocation {
+  latitude: number;
+  longitude: number;
+}

--- a/src/app/_types/weather.ts
+++ b/src/app/_types/weather.ts
@@ -1,8 +1,16 @@
-export interface HourlyWeather {
+export interface HourlyWeatherType {
   time: string;
   temperature: number;
   precipitation: number;
   weathercode: number;
+}
+
+export interface WeeklyWeatherType {
+  date: string;
+  weathercode: number;
+  tempMax: number;
+  tempMin: number;
+  precipitationProbability: number;
 }
 
 export interface WeatherResponse {
@@ -23,5 +31,6 @@ export interface WeatherResponse {
     pm10: number;
     pm2_5: number;
   };
-  hourly: HourlyWeather[];
+  hourly: HourlyWeatherType[];
+  daily: WeeklyWeatherType[];
 }

--- a/src/app/_types/weather.ts
+++ b/src/app/_types/weather.ts
@@ -13,6 +13,18 @@ export interface WeeklyWeatherType {
   precipitationProbability: number;
 }
 
+export interface CurrentType {
+  time: string;
+  temperature: number;
+  weathercode: number;
+  humidity: number;
+  windspeed: number;
+  pressure: number;
+  uv_index: number;
+  pm10: number;
+  pm2_5: number;
+}
+
 export interface WeatherResponse {
   success: boolean;
   location: {
@@ -20,17 +32,20 @@ export interface WeatherResponse {
     longitude: number;
     timezone: string;
   };
-  current: {
-    time: string;
-    temperature: number;
-    weathercode: number;
-    humidity: number;
-    windspeed: number;
-    pressure: number;
-    uv_index: number;
-    pm10: number;
-    pm2_5: number;
-  };
+  current: CurrentType;
   hourly: HourlyWeatherType[];
   daily: WeeklyWeatherType[];
 }
+
+export type IndexType = Pick<
+  CurrentType,
+  'humidity' | 'windspeed' | 'pressure' | 'uv_index' | 'pm10' | 'pm2_5'
+>;
+
+export type IndexNameType =
+  | '미세먼지'
+  | '초미세먼지'
+  | '자외선'
+  | '습도'
+  | '바람'
+  | '기압';

--- a/src/app/_types/weather.ts
+++ b/src/app/_types/weather.ts
@@ -1,0 +1,27 @@
+export interface HourlyWeather {
+  time: string;
+  temperature: number;
+  precipitation: number;
+  weathercode: number;
+}
+
+export interface WeatherResponse {
+  success: boolean;
+  location: {
+    latitude: number;
+    longitude: number;
+    timezone: string;
+  };
+  current: {
+    time: string;
+    temperature: number;
+    weathercode: number;
+    humidity: number;
+    windspeed: number;
+    pressure: number;
+    uv_index: number;
+    pm10: number;
+    pm2_5: number;
+  };
+  hourly: HourlyWeather[];
+}

--- a/src/app/_utils/getWeatherInfo.ts
+++ b/src/app/_utils/getWeatherInfo.ts
@@ -1,0 +1,19 @@
+import { weatherCode } from '../(afterlogin)/weather/_constant/weatherCode';
+
+export const getWeatherInfo = (code: number) => {
+  if (code === 0) return weatherCode.clear;
+  if (code === 1 || code === 2) return weatherCode.partlyCloudy;
+  if (code === 3) return weatherCode.overcast;
+  if (code === 45 || code === 48) return weatherCode.fog;
+  if (code >= 51 && code <= 57) return weatherCode.drizzle;
+  if (code >= 61 && code <= 67) return weatherCode.rain;
+  if (code >= 71 && code <= 77) return weatherCode.snow;
+  if (code >= 80 && code <= 82) return weatherCode.rain;
+  if (code === 95) return weatherCode.thunderstorm;
+  if (code >= 96 && code <= 99) return weatherCode.hail;
+
+  return {
+    codeName: '알 수 없음',
+    imageUrl: '/assets/weather/unknown.png',
+  };
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
         <Script
           strategy='beforeInteractive'
           type='text/javascript'
-          src={`https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${process.env.MAP_CLIENT_ID}`}
+          src={`https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${process.env.MAP_CLIENT_ID}&submodules=geocoder`}
         ></Script>
       </head>
       <body className={`antialiased`}>


### PR DESCRIPTION
## 💡 작업 내용

- [x] 날씨 API 연동 
  - [x] 현재 날씨 
  - [x] 오늘 시간대별 날씨
  - [x] 주간 날씨 
  - [x] 현재 좌표 기반 위치 표기(~~시 ~~구) 
- [x] 모바일 반응형 UI 구현


## 💡 자세한 설명

### 1️⃣ 날씨 API 연동
날씨 페이지의 `현재 날씨`, `시간대별 날씨`, `오늘 여러 기상 지표`, `주간 날씨` 정보를 받아오는 날씨 API를 연동했습니다. 
서비스 준비 중이던 주간 날씨도 구현 가능해져 진행했습니다.

날씨 API는 현재 위치는 lat, lon 좌표를 파라미터로 받습니다. 
이를 위해서 브라우저 Navigator 객체의 geolocation을 이용하여 좌표 정보를 가져오는 `useCurrentLocation` 훅을 생성했습니다. 
해당 정보를 가져오기 위해선 사용자가 위치 정보 이용 동의가 필요합니다! (페이지 접근 시 동의를 구하는 창이 뜹니다!)
동의하지 않았을 경우는 아직 구현된 UI가 따로 없는 상태입니다..!

![2025-04-28 17;40;25](https://github.com/user-attachments/assets/437af235-b6ce-4afc-9434-aeddb7d44571)

### 2️⃣ 네이버 Geocoder 서브 모듈을 이용하여 위치 표기
또한 현재 위치를 `~시~구`로 표기하기 위해 네이버의 Geocoder 서브 모듈를 사용했습니다. 
`useGetLocationName` 훅이 해당 모듈을 이용하여 주소 정보를 받아오는 훅입니다. 
모듈을 사용하기 위해 `layout.tsx` 의 스크립트를 아래와 같이 수정했습니다. 

```tsx
<Script
          strategy='beforeInteractive'
          type='text/javascript'
          src={`https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${process.env.MAP_CLIENT_ID}&submodules=geocoder`} // 파라미터 추가
        ></Script>
```

### 3️⃣ 날씨 페이지 모바일 반응형 UI
날씨 페이지 모바일 반응형 UI를 구현했습니다

![2025-04-28 17;52;06](https://github.com/user-attachments/assets/70026727-5941-4c60-a662-aa21c53c683d)

### 4️⃣ 추가 구현 사항

- 로딩 스피너
- 네비게이션 컴포넌트 레이아웃 분리 

조금 후순위이긴 하지만 여유가 있다면 진행해도 좋을 거 같습니다!

## 📗 참고 자료 (선택)
[Geocoder를 활용한 주소와 좌표 검색 API 호출하기](https://navermaps.github.io/maps.js.ncp/docs/tutorial-Geocoder-Geocoding.html)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [X] 머지할 브랜치 확인했나요?
- [X] Reviewers, Labels, Projects를 등록했나요?
- [X] 기능이 잘 동작하나요?
- [X] 불필요한 코드는 제거했나요?
