### PR TITLE
feat: 로그인 및 회원가입 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react": "^19.0.0",
         "react-big-calendar": "^1.18.0",
         "react-day-picker": "^9.6.4",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -6350,6 +6351,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react": "^19.0.0",
     "react-big-calendar": "^1.18.0",
     "react-day-picker": "^9.6.4",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/(afterlogin)/layout.tsx
+++ b/src/app/(afterlogin)/layout.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import { rehydrateAuthStore, useAuthStore } from '../store/authStore';
+import { useRouter } from 'next/navigation';
+
+export default function AfterLoginLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  const router = useRouter();
+
+  useEffect(() => {
+    rehydrateAuthStore();
+
+    const { accessToken } = useAuthStore.getState();
+    if (accessToken === null) {
+      router.push('/login');
+    }
+  }, []);
+
+  return <>{children};</>;
+}

--- a/src/app/(beforelogin)/login/page.tsx
+++ b/src/app/(beforelogin)/login/page.tsx
@@ -7,6 +7,33 @@ import useLoginMutation from '@/app/_hooks/useLoginMutation';
 import { ChangeEvent, useState } from 'react';
 import { LoginParams } from '@/app/_types/users';
 
+const initialErrors = {
+  email: '',
+  password: '',
+};
+
+const validateInputData = (loginData: LoginParams) => {
+  const errors = { ...initialErrors };
+  let isValid = true;
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  if (!loginData.email.trim()) {
+    errors.email = '아이디를 입력해주세요.';
+    isValid = false;
+  } else if (!emailRegex.test(loginData.email)) {
+    errors.email = '아이디는 이메일 형식입니다.';
+    isValid = false;
+  }
+
+  if (!loginData.password.trim()) {
+    errors.password = '비밀번호를 입력해주세요.';
+    isValid = false;
+  }
+
+  return { isValid, errors };
+};
+
 export default function Login() {
   const { mutate: loginMutate } = useLoginMutation();
 
@@ -14,9 +41,18 @@ export default function Login() {
     email: '',
     password: '',
   });
+  const [errors, setErrors] = useState(initialErrors);
 
   const handleLoginClick = (e: React.MouseEvent) => {
     e.preventDefault();
+
+    const { isValid, errors: validationErrors } = validateInputData(loginData);
+
+    if (!isValid) {
+      setErrors(validationErrors);
+      return;
+    }
+
     loginMutate(loginData);
   };
 
@@ -41,26 +77,38 @@ export default function Login() {
           <form className='text-secondary-500 flex flex-col gap-[30px]'>
             <div className='flex flex-col gap-[10px]'>
               <div className='flex flex-col gap-[6px]'>
-                <label htmlFor='id' className='text-[14px] sm:text-xl'>
+                <label
+                  htmlFor='id'
+                  className='flex items-center gap-[10px] text-[14px] sm:text-xl'
+                >
                   아이디
+                  <p className='text-error-600 text-[14px]'>{errors.email}</p>
                 </label>
                 <NormalInput
                   id='id'
                   type='text'
                   value={loginData.email}
                   onChange={e => handleInputChange('email', e)}
+                  className={errors.email && '!border-error-600'}
                   placeholder='아이디'
                 />
               </div>
               <div className='flex flex-col gap-[6px]'>
-                <label htmlFor='password' className='text-[14px] sm:text-xl'>
+                <label
+                  htmlFor='password'
+                  className='flex items-center gap-[10px] text-[14px] sm:text-xl'
+                >
                   비밀번호
+                  <p className='text-error-600 text-[14px]'>
+                    {errors.password}
+                  </p>
                 </label>
                 <NormalInput
                   id='password'
                   type='password'
                   value={loginData.password}
                   onChange={e => handleInputChange('password', e)}
+                  className={errors.password && '!border-error-600'}
                   placeholder='비밀번호'
                 />
               </div>

--- a/src/app/(beforelogin)/login/page.tsx
+++ b/src/app/(beforelogin)/login/page.tsx
@@ -6,32 +6,11 @@ import Link from 'next/link';
 import useLoginMutation from '@/app/_hooks/useLoginMutation';
 import { ChangeEvent, useState } from 'react';
 import { LoginParams } from '@/app/_types/users';
+import { validateLoginInput } from '@/app/_utils/validateUtil';
 
 const initialErrors = {
   email: '',
   password: '',
-};
-
-const validateInputData = (loginData: LoginParams) => {
-  const errors = { ...initialErrors };
-  let isValid = true;
-
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-  if (!loginData.email.trim()) {
-    errors.email = '아이디를 입력해주세요.';
-    isValid = false;
-  } else if (!emailRegex.test(loginData.email)) {
-    errors.email = '아이디는 이메일 형식입니다.';
-    isValid = false;
-  }
-
-  if (!loginData.password.trim()) {
-    errors.password = '비밀번호를 입력해주세요.';
-    isValid = false;
-  }
-
-  return { isValid, errors };
 };
 
 export default function Login() {
@@ -46,7 +25,10 @@ export default function Login() {
   const handleLoginClick = (e: React.MouseEvent) => {
     e.preventDefault();
 
-    const { isValid, errors: validationErrors } = validateInputData(loginData);
+    const { isValid, errors: validationErrors } = validateLoginInput(
+      loginData,
+      initialErrors,
+    );
 
     if (!isValid) {
       setErrors(validationErrors);
@@ -81,7 +63,7 @@ export default function Login() {
                   htmlFor='id'
                   className='flex items-center gap-[10px] text-[14px] sm:text-xl'
                 >
-                  아이디
+                  이메일
                   <p className='text-error-600 text-[14px]'>{errors.email}</p>
                 </label>
                 <NormalInput
@@ -89,8 +71,8 @@ export default function Login() {
                   type='text'
                   value={loginData.email}
                   onChange={e => handleInputChange('email', e)}
-                  className={errors.email && '!border-error-600'}
-                  placeholder='아이디'
+                  isError={errors.email ? true : false}
+                  placeholder='이메일'
                 />
               </div>
               <div className='flex flex-col gap-[6px]'>
@@ -108,7 +90,7 @@ export default function Login() {
                   type='password'
                   value={loginData.password}
                   onChange={e => handleInputChange('password', e)}
-                  className={errors.password && '!border-error-600'}
+                  isError={errors.password ? true : false}
                   placeholder='비밀번호'
                 />
               </div>

--- a/src/app/(beforelogin)/login/page.tsx
+++ b/src/app/(beforelogin)/login/page.tsx
@@ -1,8 +1,36 @@
+'use client';
+
 import SubmitButton from '@/app/_components/common/SubmitButton';
 import NormalInput from '@/app/_components/common/NormalInput';
 import Link from 'next/link';
+import useLoginMutation from '@/app/_hooks/useLoginMutation';
+import { ChangeEvent, useState } from 'react';
+import { LoginParams } from '@/app/_types/users';
 
 export default function Login() {
+  const { mutate: loginMutate } = useLoginMutation();
+
+  const [loginData, setLoginData] = useState<LoginParams>({
+    email: '',
+    password: '',
+  });
+
+  const handleLoginClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    loginMutate(loginData);
+  };
+
+  const handleInputChange = (
+    field: keyof LoginParams,
+    e?: ChangeEvent<HTMLInputElement>,
+    value?: string,
+  ) => {
+    setLoginData(prev => ({
+      ...prev,
+      [field]: e ? e.target.value : value,
+    }));
+  };
+
   return (
     <div className='relative inset-0 h-dvh w-dvw bg-[#FAFAFA]'>
       <div className='absolute top-1/2 left-1/2 flex -translate-1/2 flex-col sm:w-[392px]'>
@@ -16,7 +44,13 @@ export default function Login() {
                 <label htmlFor='id' className='text-[14px] sm:text-xl'>
                   아이디
                 </label>
-                <NormalInput id='id' type='text' placeholder='아이디' />
+                <NormalInput
+                  id='id'
+                  type='text'
+                  value={loginData.email}
+                  onChange={e => handleInputChange('email', e)}
+                  placeholder='아이디'
+                />
               </div>
               <div className='flex flex-col gap-[6px]'>
                 <label htmlFor='password' className='text-[14px] sm:text-xl'>
@@ -25,11 +59,13 @@ export default function Login() {
                 <NormalInput
                   id='password'
                   type='password'
+                  value={loginData.password}
+                  onChange={e => handleInputChange('password', e)}
                   placeholder='비밀번호'
                 />
               </div>
             </div>
-            <SubmitButton>로그인</SubmitButton>
+            <SubmitButton onClick={handleLoginClick}>로그인</SubmitButton>
           </form>
         </div>
         <div className='text-secondary-300 text-center text-[14px] sm:text-lg'>

--- a/src/app/(beforelogin)/register/page.tsx
+++ b/src/app/(beforelogin)/register/page.tsx
@@ -1,8 +1,81 @@
+'use client';
+
 import SubmitButton from '@/app/_components/common/SubmitButton';
 import NormalInput from '@/app/_components/common/NormalInput';
 import Link from 'next/link';
+import { ChangeEvent, useState } from 'react';
+import { RegisterParams } from '@/app/_types/users';
+import useRegisterMutation from '@/app/_hooks/useRegisterMutation';
 
 export default function Register() {
+  const { mutate: registerMutate } = useRegisterMutation();
+
+  const [registerData, setRegisterData] = useState<RegisterParams>({
+    username: '',
+    email: '',
+    password: '',
+  });
+  const [verifyPassword, setVerifyPassword] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+  const [usernameError, setUsernameError] = useState('');
+  const [verifyPasswordError, setVerifyPasswordError] = useState('');
+
+  const handleRegisterClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    let isValid = true;
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+    if (!registerData.email.trim()) {
+      setEmailError('아이디를 입력해주세요.');
+      isValid = false;
+    } else if (!emailRegex.test(registerData.email)) {
+      setEmailError('아이디는 이메일 형식입니다.');
+      isValid = false;
+    } else {
+      setEmailError('');
+    }
+
+    if (!registerData.username.trim()) {
+      setUsernameError('닉네임을 입력해주세요.');
+      isValid = false;
+    } else {
+      setUsernameError('');
+    }
+
+    if (!registerData.password.trim()) {
+      setPasswordError('비밀번호를 입력해주세요.');
+      isValid = false;
+    } else {
+      setPasswordError('');
+    }
+
+    if (!verifyPassword.trim()) {
+      setVerifyPasswordError('비밀번호 확인을 입력해주세요.');
+      isValid = false;
+    } else if (registerData.password !== verifyPassword) {
+      setVerifyPasswordError('비밀번호가 일치하지 않습니다.');
+      isValid = false;
+    } else {
+      setVerifyPasswordError('');
+    }
+
+    if (!isValid) return;
+    registerMutate(registerData);
+  };
+
+  const handleInputChange = (
+    field: keyof RegisterParams,
+    e?: ChangeEvent<HTMLInputElement>,
+    value?: string,
+  ) => {
+    setRegisterData(prev => ({
+      ...prev,
+      [field]: e ? e.target.value : value,
+    }));
+  };
+
   return (
     <div className='relative inset-0 h-dvh w-dvw bg-[#FAFAFA]'>
       <div className='absolute top-1/2 left-1/2 flex -translate-1/2 flex-col sm:w-[392px]'>
@@ -13,42 +86,90 @@ export default function Register() {
           <form className='text-secondary-500 flex flex-col gap-[30px]'>
             <div className='flex flex-col gap-[10px]'>
               <div className='flex flex-col gap-[6px]'>
-                <label htmlFor='id' className='text-[14px] sm:text-xl'>
+                <label
+                  htmlFor='id'
+                  className='flex items-center gap-[10px] text-[14px] sm:text-xl'
+                >
                   아이디
+                  {emailError && (
+                    <p className='text-error-600 text-[14px]'>{emailError}</p>
+                  )}
                 </label>
-                <NormalInput id='id' type='text' placeholder='아이디' />
+                <NormalInput
+                  id='id'
+                  type='email'
+                  value={registerData.email}
+                  onChange={e => handleInputChange('email', e)}
+                  className={emailError && '!border-error-600'}
+                  placeholder='아이디'
+                />
               </div>
+
               <div className='flex flex-col gap-[6px]'>
-                <label htmlFor='nickname' className='text-[14px] sm:text-xl'>
+                <label
+                  htmlFor='nickname'
+                  className='flex items-center gap-[10px] text-[14px] sm:text-xl'
+                >
                   닉네임
+                  {usernameError && (
+                    <p className='text-error-600 text-[14px]'>
+                      {usernameError}
+                    </p>
+                  )}
                 </label>
-                <NormalInput id='nickname' type='text' placeholder='닉네임' />
+                <NormalInput
+                  id='nickname'
+                  type='text'
+                  value={registerData.username}
+                  onChange={e => handleInputChange('username', e)}
+                  className={usernameError && '!border-error-600'}
+                  placeholder='닉네임'
+                />
               </div>
               <div className='flex flex-col gap-[6px]'>
-                <label htmlFor='password' className='text-[14px] sm:text-xl'>
+                <label
+                  htmlFor='password'
+                  className='flex items-center gap-[10px] text-[14px] sm:text-xl'
+                >
                   비밀번호
+                  {passwordError && (
+                    <p className='text-error-600 text-[14px]'>
+                      {passwordError}
+                    </p>
+                  )}
                 </label>
                 <NormalInput
                   id='password'
                   type='password'
+                  value={registerData.password}
+                  onChange={e => handleInputChange('password', e)}
+                  className={passwordError && '!border-error-600'}
                   placeholder='비밀번호'
                 />
               </div>
               <div className='flex flex-col gap-[6px]'>
                 <label
                   htmlFor='verifyPassword'
-                  className='text-[14px] sm:text-xl'
+                  className='flex items-center gap-[10px] text-[14px] sm:text-xl'
                 >
                   비밀번호 확인
+                  {verifyPasswordError && (
+                    <p className='text-error-600 text-[14px]'>
+                      {verifyPasswordError}
+                    </p>
+                  )}
                 </label>
                 <NormalInput
                   id='verifyPassword'
                   type='password'
+                  value={verifyPassword}
+                  onChange={e => setVerifyPassword(e.target.value)}
+                  className={verifyPasswordError && '!border-error-600'}
                   placeholder='비밀번호'
                 />
               </div>
             </div>
-            <SubmitButton>회원가입</SubmitButton>
+            <SubmitButton onClick={handleRegisterClick}>회원가입</SubmitButton>
           </form>
         </div>
         <div className='text-secondary-300 text-center text-[14px] sm:text-lg'>

--- a/src/app/(beforelogin)/register/page.tsx
+++ b/src/app/(beforelogin)/register/page.tsx
@@ -6,50 +6,13 @@ import Link from 'next/link';
 import { ChangeEvent, useState } from 'react';
 import { RegisterParams } from '@/app/_types/users';
 import useRegisterMutation from '@/app/_hooks/useRegisterMutation';
+import { validateRegisterInput } from '@/app/_utils/validateUtil';
 
 const initialErrors = {
   email: '',
   username: '',
   password: '',
   verifyPassword: '',
-};
-
-const validateInputData = (
-  registerData: RegisterParams,
-  verifyPassword: string,
-) => {
-  const errors = { ...initialErrors };
-  let isValid = true;
-
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-  if (!registerData.email.trim()) {
-    errors.email = '아이디를 입력해주세요.';
-    isValid = false;
-  } else if (!emailRegex.test(registerData.email)) {
-    errors.email = '아이디는 이메일 형식입니다.';
-    isValid = false;
-  }
-
-  if (!registerData.username.trim()) {
-    errors.username = '닉네임을 입력해주세요.';
-    isValid = false;
-  }
-
-  if (!registerData.password.trim()) {
-    errors.password = '비밀번호를 입력해주세요.';
-    isValid = false;
-  }
-
-  if (!verifyPassword.trim()) {
-    errors.verifyPassword = '비밀번호 확인을 입력해주세요.';
-    isValid = false;
-  } else if (registerData.password !== verifyPassword) {
-    errors.verifyPassword = '비밀번호가 일치하지 않습니다.';
-    isValid = false;
-  }
-
-  return { isValid, errors };
 };
 
 export default function Register() {
@@ -66,9 +29,10 @@ export default function Register() {
   const handleRegisterClick = (e: React.MouseEvent) => {
     e.preventDefault();
 
-    const { isValid, errors: validationErrors } = validateInputData(
+    const { isValid, errors: validationErrors } = validateRegisterInput(
       registerData,
       verifyPassword,
+      initialErrors,
     );
 
     if (!isValid) {
@@ -104,7 +68,7 @@ export default function Register() {
                   htmlFor='id'
                   className='flex items-center gap-[10px] text-[14px] sm:text-xl'
                 >
-                  아이디
+                  이메일
                   <p className='text-error-600 text-[14px]'>{errors.email}</p>
                 </label>
                 <NormalInput
@@ -112,8 +76,8 @@ export default function Register() {
                   type='email'
                   value={registerData.email}
                   onChange={e => handleInputChange('email', e)}
-                  className={errors.email && '!border-error-600'}
-                  placeholder='아이디'
+                  isError={errors.email ? true : false}
+                  placeholder='이메일'
                 />
               </div>
 
@@ -132,7 +96,7 @@ export default function Register() {
                   type='text'
                   value={registerData.username}
                   onChange={e => handleInputChange('username', e)}
-                  className={errors.username && '!border-error-600'}
+                  isError={errors.username ? true : false}
                   placeholder='닉네임'
                 />
               </div>
@@ -151,7 +115,7 @@ export default function Register() {
                   type='password'
                   value={registerData.password}
                   onChange={e => handleInputChange('password', e)}
-                  className={errors.password && '!border-error-600'}
+                  isError={errors.password ? true : false}
                   placeholder='비밀번호'
                 />
               </div>
@@ -170,7 +134,7 @@ export default function Register() {
                   type='password'
                   value={verifyPassword}
                   onChange={e => setVerifyPassword(e.target.value)}
-                  className={errors.verifyPassword && '!border-error-600'}
+                  isError={errors.verifyPassword ? true : false}
                   placeholder='비밀번호'
                 />
               </div>

--- a/src/app/(beforelogin)/register/page.tsx
+++ b/src/app/(beforelogin)/register/page.tsx
@@ -7,6 +7,51 @@ import { ChangeEvent, useState } from 'react';
 import { RegisterParams } from '@/app/_types/users';
 import useRegisterMutation from '@/app/_hooks/useRegisterMutation';
 
+const initialErrors = {
+  email: '',
+  username: '',
+  password: '',
+  verifyPassword: '',
+};
+
+const validateInputData = (
+  registerData: RegisterParams,
+  verifyPassword: string,
+) => {
+  const errors = { ...initialErrors };
+  let isValid = true;
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  if (!registerData.email.trim()) {
+    errors.email = '아이디를 입력해주세요.';
+    isValid = false;
+  } else if (!emailRegex.test(registerData.email)) {
+    errors.email = '아이디는 이메일 형식입니다.';
+    isValid = false;
+  }
+
+  if (!registerData.username.trim()) {
+    errors.username = '닉네임을 입력해주세요.';
+    isValid = false;
+  }
+
+  if (!registerData.password.trim()) {
+    errors.password = '비밀번호를 입력해주세요.';
+    isValid = false;
+  }
+
+  if (!verifyPassword.trim()) {
+    errors.verifyPassword = '비밀번호 확인을 입력해주세요.';
+    isValid = false;
+  } else if (registerData.password !== verifyPassword) {
+    errors.verifyPassword = '비밀번호가 일치하지 않습니다.';
+    isValid = false;
+  }
+
+  return { isValid, errors };
+};
+
 export default function Register() {
   const { mutate: registerMutate } = useRegisterMutation();
 
@@ -16,52 +61,21 @@ export default function Register() {
     password: '',
   });
   const [verifyPassword, setVerifyPassword] = useState('');
-  const [emailError, setEmailError] = useState('');
-  const [passwordError, setPasswordError] = useState('');
-  const [usernameError, setUsernameError] = useState('');
-  const [verifyPasswordError, setVerifyPasswordError] = useState('');
+  const [errors, setErrors] = useState(initialErrors);
 
   const handleRegisterClick = (e: React.MouseEvent) => {
     e.preventDefault();
 
-    let isValid = true;
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const { isValid, errors: validationErrors } = validateInputData(
+      registerData,
+      verifyPassword,
+    );
 
-    if (!registerData.email.trim()) {
-      setEmailError('아이디를 입력해주세요.');
-      isValid = false;
-    } else if (!emailRegex.test(registerData.email)) {
-      setEmailError('아이디는 이메일 형식입니다.');
-      isValid = false;
-    } else {
-      setEmailError('');
+    if (!isValid) {
+      setErrors(validationErrors);
+      return;
     }
 
-    if (!registerData.username.trim()) {
-      setUsernameError('닉네임을 입력해주세요.');
-      isValid = false;
-    } else {
-      setUsernameError('');
-    }
-
-    if (!registerData.password.trim()) {
-      setPasswordError('비밀번호를 입력해주세요.');
-      isValid = false;
-    } else {
-      setPasswordError('');
-    }
-
-    if (!verifyPassword.trim()) {
-      setVerifyPasswordError('비밀번호 확인을 입력해주세요.');
-      isValid = false;
-    } else if (registerData.password !== verifyPassword) {
-      setVerifyPasswordError('비밀번호가 일치하지 않습니다.');
-      isValid = false;
-    } else {
-      setVerifyPasswordError('');
-    }
-
-    if (!isValid) return;
     registerMutate(registerData);
   };
 
@@ -91,16 +105,14 @@ export default function Register() {
                   className='flex items-center gap-[10px] text-[14px] sm:text-xl'
                 >
                   아이디
-                  {emailError && (
-                    <p className='text-error-600 text-[14px]'>{emailError}</p>
-                  )}
+                  {errors.email}
                 </label>
                 <NormalInput
                   id='id'
                   type='email'
                   value={registerData.email}
                   onChange={e => handleInputChange('email', e)}
-                  className={emailError && '!border-error-600'}
+                  className={errors.email && '!border-error-600'}
                   placeholder='아이디'
                 />
               </div>
@@ -111,18 +123,14 @@ export default function Register() {
                   className='flex items-center gap-[10px] text-[14px] sm:text-xl'
                 >
                   닉네임
-                  {usernameError && (
-                    <p className='text-error-600 text-[14px]'>
-                      {usernameError}
-                    </p>
-                  )}
+                  {errors.username}
                 </label>
                 <NormalInput
                   id='nickname'
                   type='text'
                   value={registerData.username}
                   onChange={e => handleInputChange('username', e)}
-                  className={usernameError && '!border-error-600'}
+                  className={errors.username && '!border-error-600'}
                   placeholder='닉네임'
                 />
               </div>
@@ -132,18 +140,14 @@ export default function Register() {
                   className='flex items-center gap-[10px] text-[14px] sm:text-xl'
                 >
                   비밀번호
-                  {passwordError && (
-                    <p className='text-error-600 text-[14px]'>
-                      {passwordError}
-                    </p>
-                  )}
+                  {errors.password}
                 </label>
                 <NormalInput
                   id='password'
                   type='password'
                   value={registerData.password}
                   onChange={e => handleInputChange('password', e)}
-                  className={passwordError && '!border-error-600'}
+                  className={errors.password && '!border-error-600'}
                   placeholder='비밀번호'
                 />
               </div>
@@ -153,18 +157,14 @@ export default function Register() {
                   className='flex items-center gap-[10px] text-[14px] sm:text-xl'
                 >
                   비밀번호 확인
-                  {verifyPasswordError && (
-                    <p className='text-error-600 text-[14px]'>
-                      {verifyPasswordError}
-                    </p>
-                  )}
+                  {errors.verifyPassword}
                 </label>
                 <NormalInput
                   id='verifyPassword'
                   type='password'
                   value={verifyPassword}
                   onChange={e => setVerifyPassword(e.target.value)}
-                  className={verifyPasswordError && '!border-error-600'}
+                  className={errors.verifyPassword && '!border-error-600'}
                   placeholder='비밀번호'
                 />
               </div>

--- a/src/app/(beforelogin)/register/page.tsx
+++ b/src/app/(beforelogin)/register/page.tsx
@@ -105,7 +105,7 @@ export default function Register() {
                   className='flex items-center gap-[10px] text-[14px] sm:text-xl'
                 >
                   아이디
-                  {errors.email}
+                  <p className='text-error-600 text-[14px]'>{errors.email}</p>
                 </label>
                 <NormalInput
                   id='id'
@@ -123,7 +123,9 @@ export default function Register() {
                   className='flex items-center gap-[10px] text-[14px] sm:text-xl'
                 >
                   닉네임
-                  {errors.username}
+                  <p className='text-error-600 text-[14px]'>
+                    {errors.username}
+                  </p>
                 </label>
                 <NormalInput
                   id='nickname'
@@ -140,7 +142,9 @@ export default function Register() {
                   className='flex items-center gap-[10px] text-[14px] sm:text-xl'
                 >
                   비밀번호
-                  {errors.password}
+                  <p className='text-error-600 text-[14px]'>
+                    {errors.password}
+                  </p>
                 </label>
                 <NormalInput
                   id='password'
@@ -157,7 +161,9 @@ export default function Register() {
                   className='flex items-center gap-[10px] text-[14px] sm:text-xl'
                 >
                   비밀번호 확인
-                  {errors.verifyPassword}
+                  <p className='text-error-600 text-[14px]'>
+                    {errors.verifyPassword}
+                  </p>
                 </label>
                 <NormalInput
                   id='verifyPassword'

--- a/src/app/_apis/tasks.ts
+++ b/src/app/_apis/tasks.ts
@@ -3,7 +3,6 @@ import { TaskPayload, TaskWithDuration } from '../_types';
 import { getWeekOfMonth } from 'date-fns';
 import { useAuthStore } from '../store/authStore';
 import { validateToken } from './users';
-import { useRouter } from 'next/navigation';
 
 type TaskParams = {
   year: number;
@@ -26,9 +25,7 @@ api.interceptors.request.use(
 
         return config;
       } catch (error) {
-        const router = useRouter();
-        router.push('/login');
-
+        window.location.href = '/login';
         return Promise.reject(error);
       }
     } else {

--- a/src/app/_apis/users.ts
+++ b/src/app/_apis/users.ts
@@ -28,3 +28,9 @@ export const validateToken = async () => {
 
   return response;
 };
+
+export const refreshAccessToken = async (refreshToken: string) => {
+  const response = await api.post('/users/refresh', refreshToken);
+
+  return response;
+};

--- a/src/app/_apis/users.ts
+++ b/src/app/_apis/users.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { LoginParams, RegisterParams } from '../_types/users';
+import { useAuthStore } from '../store/authStore';
 
 export const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_SERVER_URL,
@@ -13,6 +14,17 @@ export const register = async (registerData: RegisterParams) => {
 
 export const login = async (loginData: LoginParams) => {
   const response = await api.post('/users/login', loginData);
+
+  return response;
+};
+
+export const validateToken = async () => {
+  const accessToken = useAuthStore.getState().accessToken;
+  const response = await api.get('/users/validate', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
 
   return response;
 };

--- a/src/app/_apis/users.ts
+++ b/src/app/_apis/users.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+import { LoginParams, RegisterParams } from '../_types/users';
+
+export const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_SERVER_URL,
+});
+
+export const register = async (registerData: RegisterParams) => {
+  const response = await api.post('/join', registerData);
+
+  return response;
+};
+
+export const login = async (loginData: LoginParams) => {
+  const response = await api.post('/users/login', loginData);
+
+  return response;
+};

--- a/src/app/_components/nav/Navigation.tsx
+++ b/src/app/_components/nav/Navigation.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useAuthStore } from '@/app/store/authStore';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -15,8 +16,9 @@ interface NavItem {
 
 function Navigation() {
   const pathname = usePathname();
-  const [isLoggedIn] = useState(false);
+  const { checkLoggedIn, clearTokens } = useAuthStore();
   const [isOpen, setIsOpen] = useState(false);
+  const isLoggedIn = checkLoggedIn();
 
   const navItems: NavItem[] = [
     {
@@ -55,6 +57,10 @@ function Navigation() {
     }
   };
 
+  const handleLogout = () => {
+    clearTokens();
+  };
+
   return (
     <>
       <div className='text-secondary-500 bg-primary-0 border-primary-100 z-10 flex min-w-[400px] items-center justify-between border-b-1 px-[24px] py-[20px] sm:hidden'>
@@ -72,7 +78,7 @@ function Navigation() {
             className='bg-secondary-400 fixed inset-0 opacity-30 sm:hidden'
             onClick={() => setIsOpen(false)}
           />
-          <div className='bg-primary-0 absolute top-[86px] w-full px-[20px] py-[18px] z-10 shadow-md sm:hidden'>
+          <div className='bg-primary-0 absolute top-[86px] z-10 w-full px-[20px] py-[18px] shadow-md sm:hidden'>
             <ul className='text-secondary-300 flex flex-col gap-y-[12px]'>
               {navItems.map(navItem => (
                 <Link
@@ -123,6 +129,7 @@ function Navigation() {
         <Link
           href={'/login'}
           className={`${isLoggedIn ? 'bg-[url(/assets/logout.png)] hover:bg-[url(/assets/logout-dark.png)]' : 'bg-[url(/assets/login.png)] hover:bg-[url(/assets/login-dark.png)]'} text-secondary-300 hover:text-secondary-500 absolute bottom-[24px] mx-[20px] flex cursor-pointer items-center bg-left bg-no-repeat py-[10px] hover:rounded-[10px]`}
+          onClick={isLoggedIn ? handleLogout : undefined}
         >
           {isLoggedIn ? (
             <span className='ml-[32px] text-[14px] font-semibold'>

--- a/src/app/_hooks/useLoginMutation.ts
+++ b/src/app/_hooks/useLoginMutation.ts
@@ -1,20 +1,23 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { login } from '../_apis/users';
 import { useAuthStore } from '../store/authStore';
 import { useRouter } from 'next/navigation';
+import { AxiosError } from 'axios';
 
 const useLoginMutation = () => {
-  const queryClient = useQueryClient();
   const setTokens = useAuthStore(state => state.setTokens);
   const router = useRouter();
 
   return useMutation({
-    mutationKey: ['login'],
     mutationFn: login,
-    onError: error => console.error('로그인 실패:', error),
+    onError: error => {
+      const err = error as AxiosError<{ message: string }>;
+      const message =
+        err.response?.data?.message || '로그인에 실패하였습니다.';
+      alert(message);
+    },
     onSuccess: data => {
       setTokens(data.data.accessToken, data.data.refreshToken);
-      queryClient.invalidateQueries({ queryKey: ['login'] });
       router.push('/');
     },
   });

--- a/src/app/_hooks/useLoginMutation.ts
+++ b/src/app/_hooks/useLoginMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { login } from '../_apis/users';
+import { useAuthStore } from '../store/authStore';
+import { useRouter } from 'next/navigation';
+
+const useLoginMutation = () => {
+  const queryClient = useQueryClient();
+  const setTokens = useAuthStore(state => state.setTokens);
+  const router = useRouter();
+
+  return useMutation({
+    mutationKey: ['login'],
+    mutationFn: login,
+    onError: error => console.error('로그인 실패:', error),
+    onSuccess: data => {
+      setTokens(data.data.accessToken, data.data.refreshToken);
+      queryClient.invalidateQueries({ queryKey: ['login'] });
+      router.push('/');
+    },
+  });
+};
+
+export default useLoginMutation;

--- a/src/app/_hooks/useRegisterMutation.ts
+++ b/src/app/_hooks/useRegisterMutation.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { register } from '../_apis/users';
+import { useRouter } from 'next/navigation';
+import { AxiosError } from 'axios';
+
+const useRegisterMutation = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return useMutation({
+    mutationKey: ['register'],
+    mutationFn: register,
+    onError: error => {
+      const err = error as AxiosError<{ message: string }>;
+      const message =
+        err.response?.data?.message || '회원가입에 실패하였습니다.';
+      alert(message);
+    },
+    onSuccess: () => {
+      if (
+        window.confirm('회원가입에 성공했습니다! 로그인 페이지로 이동합니다.')
+      ) {
+        queryClient.invalidateQueries({ queryKey: ['register'] });
+        router.push('/login');
+      }
+    },
+  });
+};
+
+export default useRegisterMutation;

--- a/src/app/_hooks/useRegisterMutation.ts
+++ b/src/app/_hooks/useRegisterMutation.ts
@@ -1,14 +1,12 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { register } from '../_apis/users';
 import { useRouter } from 'next/navigation';
 import { AxiosError } from 'axios';
 
 const useRegisterMutation = () => {
-  const queryClient = useQueryClient();
   const router = useRouter();
 
   return useMutation({
-    mutationKey: ['register'],
     mutationFn: register,
     onError: error => {
       const err = error as AxiosError<{ message: string }>;
@@ -20,7 +18,6 @@ const useRegisterMutation = () => {
       if (
         window.confirm('회원가입에 성공했습니다! 로그인 페이지로 이동합니다.')
       ) {
-        queryClient.invalidateQueries({ queryKey: ['register'] });
         router.push('/login');
       }
     },

--- a/src/app/_types/users.ts
+++ b/src/app/_types/users.ts
@@ -1,0 +1,10 @@
+export interface LoginParams {
+  email: string;
+  password: string;
+}
+
+export interface RegisterParams {
+  username: string;
+  email: string;
+  password: string;
+}

--- a/src/app/_types/users.ts
+++ b/src/app/_types/users.ts
@@ -8,3 +8,13 @@ export interface RegisterParams {
   email: string;
   password: string;
 }
+
+export interface InitialErrors {
+  email: string;
+  password: string;
+}
+
+export interface RegisterErrors extends InitialErrors {
+  username: string;
+  verifyPassword: string;
+}

--- a/src/app/_utils/validateUtil.ts
+++ b/src/app/_utils/validateUtil.ts
@@ -1,4 +1,10 @@
 import { isAfter, isEqual, isSameDay } from 'date-fns';
+import {
+  InitialErrors,
+  LoginParams,
+  RegisterErrors,
+  RegisterParams,
+} from '../_types/users';
 
 export const validateIsBlank = (value: string) => {
   if (value === '') return true;
@@ -21,4 +27,68 @@ export const validateIsAfterDateTime = (start: Date, end: Date) => {
   if (!isSameDay(start, end) || isEqual(start, end)) return false;
 
   return isAfter(start, end);
+};
+
+export const validateLoginInput = (
+  loginData: LoginParams,
+  initialErrors: InitialErrors,
+) => {
+  const errors = { ...initialErrors };
+  let isValid = true;
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  if (!loginData.email.trim()) {
+    errors.email = '아이디를 입력해주세요.';
+    isValid = false;
+  } else if (!emailRegex.test(loginData.email)) {
+    errors.email = '아이디는 이메일 형식입니다.';
+    isValid = false;
+  }
+
+  if (!loginData.password.trim()) {
+    errors.password = '비밀번호를 입력해주세요.';
+    isValid = false;
+  }
+
+  return { isValid, errors };
+};
+
+export const validateRegisterInput = (
+  registerData: RegisterParams,
+  verifyPassword: string,
+  initialErrors: RegisterErrors,
+) => {
+  const errors = { ...initialErrors };
+  let isValid = true;
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  if (!registerData.email.trim()) {
+    errors.email = '아이디를 입력해주세요.';
+    isValid = false;
+  } else if (!emailRegex.test(registerData.email)) {
+    errors.email = '아이디는 이메일 형식입니다.';
+    isValid = false;
+  }
+
+  if (!registerData.username.trim()) {
+    errors.username = '닉네임을 입력해주세요.';
+    isValid = false;
+  }
+
+  if (!registerData.password.trim()) {
+    errors.password = '비밀번호를 입력해주세요.';
+    isValid = false;
+  }
+
+  if (!verifyPassword.trim()) {
+    errors.verifyPassword = '비밀번호 확인을 입력해주세요.';
+    isValid = false;
+  } else if (registerData.password !== verifyPassword) {
+    errors.verifyPassword = '비밀번호가 일치하지 않습니다.';
+    isValid = false;
+  }
+
+  return { isValid, errors };
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import TaskModal from './_components/tasks/TaskModal';
 import useGetTaskQuery from './_hooks/useGetTaskQuery';
+import { rehydrateAuthStore } from './store/authStore';
 
 export default function Dashboard() {
   const [isOpen, setIsOpen] = useState(false);
@@ -30,6 +31,7 @@ export default function Dashboard() {
   const addTask = () => setIsOpen(true);
 
   useEffect(() => {
+    rehydrateAuthStore();
     const interval = setInterval(() => {
       getCurrentTime();
     }, 1000);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,8 @@ import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import TaskModal from './_components/tasks/TaskModal';
 import useGetTaskQuery from './_hooks/useGetTaskQuery';
-import { rehydrateAuthStore } from './store/authStore';
+import { rehydrateAuthStore, useAuthStore } from './store/authStore';
+import { useRouter } from 'next/navigation';
 
 export default function Dashboard() {
   const [isOpen, setIsOpen] = useState(false);
@@ -15,6 +16,7 @@ export default function Dashboard() {
   const [today, setToday] = useState('');
   const [finishedTaskCount, setFinishedTaskCount] = useState(0);
 
+  const router = useRouter();
   const { data: taskList = [] } = useGetTaskQuery('day');
 
   const getCurrentTime = () => {
@@ -32,6 +34,12 @@ export default function Dashboard() {
 
   useEffect(() => {
     rehydrateAuthStore();
+    
+    const { accessToken } = useAuthStore.getState();
+    if (accessToken === null) {
+      router.push('/login');
+    }
+
     const interval = setInterval(() => {
       getCurrentTime();
     }, 1000);

--- a/src/app/store/authStore.ts
+++ b/src/app/store/authStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { devtools, persist } from 'zustand/middleware';
+import { persist } from 'zustand/middleware';
 
 interface AuthState {
   accessToken: string | null;
@@ -10,24 +10,22 @@ interface AuthState {
 }
 
 export const useAuthStore = create<AuthState>()(
-  devtools(
-    persist(
-      (set, get) => ({
-        accessToken: null,
-        refreshToken: null,
-        setTokens: (accessToken, refreshToken) =>
-          set({ accessToken, refreshToken }),
-        clearTokens: () => set({ accessToken: null, refreshToken: null }),
-        checkLoggedIn: () => {
-          const { accessToken } = get();
-          return accessToken !== null;
-        },
-      }),
-      {
-        name: 'authToken',
-        skipHydration: true,
+  persist(
+    (set, get) => ({
+      accessToken: null,
+      refreshToken: null,
+      setTokens: (accessToken, refreshToken) =>
+        set({ accessToken, refreshToken }),
+      clearTokens: () => set({ accessToken: null, refreshToken: null }),
+      checkLoggedIn: () => {
+        const { accessToken } = get();
+        return accessToken !== null;
       },
-    ),
+    }),
+    {
+      name: 'authToken',
+      skipHydration: true,
+    },
   ),
 );
 

--- a/src/app/store/authStore.ts
+++ b/src/app/store/authStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
+
+interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+  setTokens: (accessToken: string, refreshToken: string) => void;
+  clearTokens: () => void;
+  checkLoggedIn: () => boolean;
+}
+
+export const useAuthStore = create<AuthState>()(
+  devtools(
+    persist(
+      (set, get) => ({
+        accessToken: null,
+        refreshToken: null,
+        setTokens: (accessToken, refreshToken) =>
+          set({ accessToken, refreshToken }),
+        clearTokens: () => set({ accessToken: null, refreshToken: null }),
+        checkLoggedIn: () => {
+          const { accessToken } = get();
+          return accessToken !== null;
+        },
+      }),
+      {
+        name: 'authToken',
+        skipHydration: true,
+      },
+    ),
+  ),
+);
+
+export const rehydrateAuthStore = () => {
+  const store = useAuthStore.persist;
+  const { accessToken } = useAuthStore.getState();
+
+  if (typeof window !== 'undefined' && accessToken === null) {
+    store.rehydrate();
+  }
+};


### PR DESCRIPTION
## 💡 작업 내용

- [x] 로그인 및 회원가입 API 연동
- [x] 로그인 및 회원가입 input에 유효성 검사 추가
- [x] 토큰 만료 시 로그인 화면으로 돌아가기
- [x] 인터셉터 사용하여 header에 토큰 보내기

## 💡 자세한 설명

### 1️⃣ API 연동
로그인 및 회원가입 API를 연동하였습니다. `useLoginMutation`과 `useRegisterMutation` 훅을 만들어 사용하였으며, 에러가 나는 경우 받아오는 에러 메세지를 alert 창을 이용해 띄우도록 하였습니다.

로그인이 성공할 경우 대시보드 창으로 이동하며, 회원가입이 성공할 경우 로그인 페이지로의 이동여부를 결정하는 alert 창이 나타납니다.

![login-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/e8600de9-8735-4045-b96a-5248477d252d)

![Untitled-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/bbac38bf-2517-4325-92ad-69f69bc17f80)


### 2️⃣ zustand 적용
로그인 시 받아오는 토큰을 저장하기 위해 zustand를 적용하고 `store` 폴더 내부에 `authStore.ts` 를 만들어 해당 코드를 작성하였습니다.
localStorage를 따로 사용해야 할까 찾아보았는데, zustand의 `persist` 미들웨어를 사용하여 스토리지에 상태를 저장하고 불러올 수 있다고 합니다!

토큰을 저장하는 부분은 다음과 같습니다.
```tsx
export const useAuthStore = create<AuthState>()(
  persist(
    (set, get) => ({
      accessToken: null,
      refreshToken: null,
      setTokens: (accessToken, refreshToken) =>
        set({ accessToken, refreshToken }),
      clearTokens: () => set({ accessToken: null, refreshToken: null }),
      checkLoggedIn: () => {
        const { accessToken } = get();
        return accessToken !== null;
      },
    }),
    {
      name: 'authToken',
      skipHydration: true,
    },
  ),
);
```
이 때 새로고침 시 hydration mismatch 오류가 발생하였는데, 스토어의 초깃값과 로컬 스토리지의 값이 달라서 (서버에서는 저장된 상태값이 없는 상태로 시작이 되는데, 클라이언트에서는 스토리지에 저장된 값이 이미 있어서) 발생한다고 하네요...! 그래서 일단 `skipHydration`을 통해 최초 하이드레이션을 건너뛰게 하였습니다.

하이드레이션을 호출하는 부분은 다음과 같습니다.
```tsx
export const rehydrateAuthStore = () => {
  const store = useAuthStore.persist;
  const { accessToken } = useAuthStore.getState();

  if (typeof window !== 'undefined' && accessToken === null) {
    store.rehydrate();
  }
};
```
서버사이드 렌더링이 끝났고, 토큰이 없는 경우 하이드레이션을 해주도록 하였습니다. 이 함수는 대시보드 페이지에서 초기 실행 시 한번만 호출됩니다.

### 3️⃣ 유효성 검사 추가 
로그인 및 회원가입의 input에 유효성 검사를 추가하였습니다.

각각 추가된 유효성 검사 목록입니다.
| 로그인 | 회원가입 |
| --- | --- |
| - 빈칸 여부 확인 <br> - 아이디 입력 시 이메일 형식 확인  | - 빈칸 여부 확인 <br> - 아이디 입력 시 이메일 형식 확인 <br> - 비밀번호와 비밀번호 확인의 일치 여부 확인|

### 4️⃣ 인터셉터 사용
받아온 토큰을 다시 백엔드로 보내기 위해 인터셉터를 사용하였습니다. 일정을 가져오는 요청을 보내기 전에 토큰의 유효성을 검사하는 api를 먼저 호출하며, 유효성 검사를 통과하지 못하면 로그인 화면으로 리다이렉션 합니다. 토큰의 유효기간이 1시간이라 2번밖에 테스트해보지 못하였습니다...
```tsx
api.interceptors.request.use(
  async config => {
    const accessToken = useAuthStore.getState().accessToken;

    if (accessToken) {
      try {
        await validateToken();

        return config;
      } catch (error) {
        window.location.href = '/login';
        return Promise.reject(error);
      }
    } else {
      return config;
    }
  },
  error => {
    return Promise.reject(error);
  },
);
```

### *️⃣ 기타
해당 코드 머지 시 로그인을 하지 않고는 대시보드에 진입할 수 없게 됩니다..!
머지 후에는 노션 api 문서에 기재되어있는 아이디와 비밀번호로 로그인 하시면 될 것 같습니다.

## 📗 참고 자료 (선택)

[Zustand Persist Middleware 및 하이드레이션](https://www.heropy.dev/s/70)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
