### PR TITLE
fix: 길찾기 시간 포맷 수정

### DIFF
--- a/src/app/(afterlogin)/calendar/daily/page.tsx
+++ b/src/app/(afterlogin)/calendar/daily/page.tsx
@@ -11,6 +11,8 @@ import MapDisplay from '../_components/MapDisplay';
 import TaskModal from '@/app/_components/tasks/TaskModal';
 import useGetTaskQuery from '@/app/_hooks/useGetTaskQuery';
 import RouteInfo from '../_components/RouteInfo';
+import { formatSecondToMinute } from '@/app/_utils/dateTimeUtil';
+import { formatInTimeZone } from 'date-fns-tz';
 
 export default function Daily() {
   const [isOpen, setIsOpen] = useState(false);
@@ -88,7 +90,7 @@ export default function Daily() {
                               </span>
                             </div>
                             <span className='bg-primary-200 rounded-[5px] px-[4px] py-[2px] text-[14px] font-bold sm:text-[16px]'>
-                              {task.travel_duration}
+                              {formatSecondToMinute(task.travel_duration)}
                             </span>
                           </div>
                         )}
@@ -100,7 +102,11 @@ export default function Daily() {
                               </span>
                             </div>
                             <span className='bg-primary-200 rounded-[5px] px-[4px] py-[2px] text-[14px] font-bold sm:text-[16px]'>
-                              {task.recommended_departure_time}
+                              {formatInTimeZone(
+                                new Date(task.recommended_departure_time),
+                                'UTC',
+                                'hh:mm aa',
+                              )}
                             </span>
                           </div>
                         )}

--- a/src/app/_utils/dateTimeUtil.ts
+++ b/src/app/_utils/dateTimeUtil.ts
@@ -1,4 +1,10 @@
-import { format, setHours, setMinutes } from 'date-fns';
+import {
+  format,
+  secondsToHours,
+  secondsToMinutes,
+  setHours,
+  setMinutes,
+} from 'date-fns';
 
 export const formatTime = (date: string | Date) => {
   return new Intl.DateTimeFormat('en-US', {
@@ -21,3 +27,14 @@ export const applyTimeToDate = (date: Date, time: string) => {
 
 export const formatDateISO8601 = (date: Date) =>
   format(date, "yyyy-MM-dd'T'HH:mm:ss");
+
+export const formatSecondToMinute = (timeString: string) => {
+  const time = parseInt(timeString);
+  const hour = secondsToHours(time);
+  const minute = secondsToMinutes(time) - hour * 60;
+
+  if (hour > 0) {
+    return `${hour}시간 ${minute}분`;
+  }
+  return `${minute}분`;
+};


### PR DESCRIPTION
## 💡 작업 내용

- [x] 길찾기 시간 포맷 수정

## 💡 자세한 설명

### 1️⃣ 길찾기 시간 포맷 수정
길찾기 부분에 나오는 시간 형식을 수정하였습니다.
기존의 데이터는 다음과 같이 오고 있었는데

```json
"travel_duration": "14분",
"recommended_departure_time": "2025-04-27T09:46:00"
```

아래와 같이 변경되면서 시간 표시가 바뀌게 되었습니다.

```json
"travel_duration": 3402,
"recommended_departure_time": "2025-04-30T08:03:32.000Z"
```

`travel_duration`은 초 단위로 받고 있기 때문에 시간과 분으로 나타내기 위한 함수를 만들어두었습니다.
```tsx
export const formatSecondToMinute = (timeString: string) => {
  const time = parseInt(timeString);
  const hour = secondsToHours(time);
  const minute = secondsToMinutes(time) - hour * 60;

  if (hour > 0) {
    return `${hour}시간 ${minute}분`;
  }
  return `${minute}분`;
};
```

`recommended_departure_time`은 간단히 date-fns-tz의 `formatInTimeZone` 사용하여 변경하였습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
