### PR TITLE
feat: 대시보드 페이지에 현재 날씨 및 Top 뉴스 정보 추가

### DIFF
--- a/src/app/(afterlogin)/news/DashBoardTopNews.tsx
+++ b/src/app/(afterlogin)/news/DashBoardTopNews.tsx
@@ -14,14 +14,22 @@ interface TopNewsArticleProps {
 function TopNewsArticle({ article }: TopNewsArticleProps) {
   return (
     <div className='flex gap-[10px]'>
-      <div className='relative h-[50px] w-[50px] flex-shrink-0'>
-        <Image
-          src={article.image_url}
-          alt='뉴스 썸네일 이미지'
-          fill
-          className='rounded-[10px] object-cover'
-        />
-      </div>
+      {article.image_url ? (
+        <div className='relative h-[50px] w-[50px] flex-shrink-0'>
+          <Image
+            src={article.image_url}
+            alt='뉴스 썸네일 이미지'
+            fill
+            className='rounded-[10px] object-cover'
+          />
+        </div>
+      ) : (
+        <div className='border-primary-200 inline-flex h-[50px] w-[50px] flex-shrink-0 items-center justify-center rounded-[10px] border'>
+          <div className='relative h-[18px] w-[18px]'>
+            <Image src='/assets/gallery.png' alt='기본 썸네일 이미지' fill />
+          </div>
+        </div>
+      )}
       <Link
         href={article.link}
         className='text-overflow-2-line hover:underline'

--- a/src/app/(afterlogin)/news/DashBoardTopNews.tsx
+++ b/src/app/(afterlogin)/news/DashBoardTopNews.tsx
@@ -46,7 +46,7 @@ function DashBoardTopNews() {
   if (isLoading) {
     return (
       <div className='flex h-full items-center justify-center'>
-        <Lottie animationData={spinner} style={{ width: 150, height: 150 }} />
+        <Lottie animationData={spinner} style={{ width: 50, height: 50 }} />
       </div>
     );
   }

--- a/src/app/(afterlogin)/news/DashBoardTopNews.tsx
+++ b/src/app/(afterlogin)/news/DashBoardTopNews.tsx
@@ -1,0 +1,71 @@
+import useGetNewsQuery from '@/app/_hooks/useGetNewsQuery';
+import { NewsArticle } from '@/app/_types/news';
+import Image from 'next/image';
+import spinner from '@/assets/lottie/spinner.json';
+import dynamic from 'next/dynamic';
+import Link from 'next/link';
+
+const Lottie = dynamic(() => import('lottie-react'), { ssr: false });
+
+interface TopNewsArticleProps {
+  article: NewsArticle;
+}
+
+function TopNewsArticle({ article }: TopNewsArticleProps) {
+  return (
+    <div className='flex gap-[10px]'>
+      <div className='relative h-[50px] w-[50px] flex-shrink-0'>
+        <Image
+          src={article.image_url}
+          alt='뉴스 썸네일 이미지'
+          fill
+          className='rounded-[10px] object-cover'
+        />
+      </div>
+      <Link
+        href={article.link}
+        className='text-overflow-2-line hover:underline'
+      >
+        {article.title}
+      </Link>
+    </div>
+  );
+}
+
+function DashBoardTopNews() {
+  const { data: newsData, isLoading, isError } = useGetNewsQuery('top');
+
+  if (isLoading) {
+    return (
+      <div className='flex h-full items-center justify-center'>
+        <Lottie animationData={spinner} style={{ width: 150, height: 150 }} />
+      </div>
+    );
+  }
+
+  if (
+    isError ||
+    !newsData ||
+    !newsData.articles ||
+    (newsData.articles && newsData.articles.length === 0)
+  ) {
+    return (
+      <div className='flex h-full items-center justify-center'>
+        뉴스를 불러오지 못했습니다. 잠시후 다시 시도해주세요
+      </div>
+    );
+  }
+
+  return (
+    <div className='border-primary-200 bg-primary-0 flex flex-col gap-[18px] rounded-2xl border px-[30px] py-[26px]'>
+      <p className='text-secondary-500 text-[20px] font-semibold'>Top News</p>
+      <div className='flex flex-col gap-[15px]'>
+        {newsData.articles.map(article => (
+          <TopNewsArticle key={article.article_id} article={article} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default DashBoardTopNews;

--- a/src/app/(afterlogin)/weather/CurrentWeather.tsx
+++ b/src/app/(afterlogin)/weather/CurrentWeather.tsx
@@ -5,7 +5,7 @@ import { WeatherInfo } from './_constant/weatherCode';
 
 interface CurrentWeatherProps {
   location: string;
-  currentTime: string;
+  currentTime?: string;
   temperature: string;
   weatherInfo: WeatherInfo;
 }
@@ -31,18 +31,20 @@ function CurrentWeather({
             {location}
           </p>
         </div>
-        <div className='text-secondary-400 flex flex-col items-end text-[14px] font-medium text-nowrap sm:flex-row sm:gap-[10px] sm:text-2xl'>
-          <p>
-            {format(currentTime, 'M월 d일(eee)', {
-              locale: ko,
-            })}
-          </p>
-          <p>
-            {format(currentTime, ' a h:mm', {
-              locale: ko,
-            })}
-          </p>
-        </div>
+        {currentTime && (
+          <div className='text-secondary-400 flex flex-col items-end text-[14px] font-medium text-nowrap sm:flex-row sm:gap-[10px] sm:text-2xl'>
+            <p>
+              {format(currentTime, 'M월 d일(eee)', {
+                locale: ko,
+              })}
+            </p>
+            <p>
+              {format(currentTime, ' a h:mm', {
+                locale: ko,
+              })}
+            </p>
+          </div>
+        )}
       </div>
       <div className='flex items-center gap-[15px]'>
         <div className='relative h-[76px] w-[76px] sm:h-[96px] sm:w-[96px]'>


### PR DESCRIPTION
## 💡 작업 내용

- [x] 대시보드 날씨 정보 추가 
- [x] 대시보드 Top 뉴스 정보 추가
- [x] 대시보드 모바일 뷰 수정

## 💡 자세한 설명

### 1️⃣ 대시보드 페이지 
![image](https://github.com/user-attachments/assets/338cec0b-a62a-4f1a-a32c-d01acfcee83e)
현재 위치 기반 날씨 정보와 Top 뉴스 (5개) 정보를 불러오도록 했습니다! 기존에 구현되어있는 API 사용했습니다!

### 2️⃣ 모바일 뷰 수정 
현재 시간을 알려주는 부분 위치가 수정되었습니다! 
추가된 날씨, 뉴스 UI 모바일 반응형으로 구현했습니다!

![2025-04-30 11;41;15](https://github.com/user-attachments/assets/78b739da-ec0f-4dd3-995a-8ceba50c49b8)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
