### PR TITLE
fix: 일정 관리 타임존 버그 수정 (일간, 주간, 월간) 

### DIFF
--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -169,9 +169,6 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
       end_time: value.end_time.toISOString(),
     };
 
-    console.log('value', value.start_time);
-    console.log('newTask', newTask.start_time);
-
     switch (mode) {
       case 'add':
         addTaskMutate(newTask);

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -21,7 +21,6 @@ import {
   validateIsBlank,
 } from '@/app/_utils/validateUtil';
 import isEqual from 'lodash/isEqual';
-import { formatDateISO8601 } from '@/app/_utils/dateTimeUtil';
 import useAddTaskMutation from '@/app/_hooks/useAddTaskMutation';
 import useEditTaskMutation from '@/app/_hooks/useEditTaskMutation';
 import useDeleteTaskMutation from '@/app/_hooks/useDeleteTaskMutation';
@@ -166,9 +165,12 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
   const handleSaveTask = () => {
     const newTask: TaskPayload = {
       ...value,
-      start_time: formatDateISO8601(value.start_time),
-      end_time: formatDateISO8601(value.end_time),
+      start_time: value.start_time.toISOString(),
+      end_time: value.end_time.toISOString(),
     };
+
+    console.log('value', value.start_time);
+    console.log('newTask', newTask.start_time);
 
     switch (mode) {
       case 'add':

--- a/src/app/_utils/dateTimeUtil.ts
+++ b/src/app/_utils/dateTimeUtil.ts
@@ -1,11 +1,10 @@
-import { format, setHours, setMinutes } from 'date-fns';
+import { setHours, setMinutes } from 'date-fns';
 
 export const formatTime = (date: string | Date) => {
   return new Intl.DateTimeFormat('en-US', {
     hour: 'numeric',
     minute: '2-digit',
     hour12: true,
-    timeZone: 'UTC',
   }).format(new Date(date));
 };
 
@@ -18,6 +17,3 @@ export const applyTimeToDate = (date: Date, time: string) => {
   const [hours, minutes] = parseTimeString(time);
   return setHours(setMinutes(date, minutes), hours);
 };
-
-export const formatDateISO8601 = (date: Date) =>
-  format(date, "yyyy-MM-dd'T'HH:mm:ss");


### PR DESCRIPTION
## 💡 작업 내용

- [x]  UTC 시간으로 시간 저장되도록 수정 (조회 시 KST 시간으로 변환)

## 💡 자세한 설명

### 버그 설명 
주간 및 월간 달력에 표시되는 일정이 등록한 시간과 다르게 표시되는 문제입니다. 
(등록한 시간 보다 +9시간 후로 등록이 됨)

### 문제 원인 
일정 등록 시 서버로 보내지는 시간은 타임존 정보가 없는 한국 시간 문자열이였습니다 (YYYY-MM-DDTHH:mm:ss 형식)
하지만 서버에서 한국 기준인 시간을 UTC 기준으로 판단하여 DB에 저장한 듯 합니다! 
그래서 조회했을 때 이미 한국 시간인데 한번 더 KST로 변환되어 +9시간으로 출력되는 것이 원인입니다
#16 의 3️⃣ 문제와 동일한 문제라고 생각합니다!

### 해결 
일정을 등록할 때 `toISOstring()` 메서드를 이용하여 한국 기준 시간을 UTC로 변환한 후 
타임존(Z) 정보를 담은 `YYYY-MM-DDTHH:mm:ss.sssZ` 형식으로 등록합니다.
이후 조회 시 작성되어있던 그대로 진행합니다 (KST로 변환)

#16에서 수정해주셨던 일간 조회 시간 형식 변환 부분도 수정해두었습니다! 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
