### PR TITLE
feat: 날씨 정보 로딩 스피너 추가 및 위치 액세스 비허용 시 피드백 UI 구현

### DIFF
--- a/src/app/(afterlogin)/news/Articles.tsx
+++ b/src/app/(afterlogin)/news/Articles.tsx
@@ -16,7 +16,7 @@ function Articles({ category }: ArticlesProps) {
   if (isLoading) {
     return (
       <div className='flex h-full items-center justify-center'>
-        <Lottie animationData={spinner} style={{ width: 150, height: 150 }} />
+        <Lottie animationData={spinner} style={{ width: 50, height: 50 }} />
       </div>
     );
   }

--- a/src/app/(afterlogin)/news/CategoryButton.tsx
+++ b/src/app/(afterlogin)/news/CategoryButton.tsx
@@ -8,7 +8,7 @@ function CategoryButton({ children, isActive, onClick }: CategoryButtonProps) {
   return (
     <button
       onClick={onClick}
-      className={`${isActive ? 'bg-primary-400 text-primary-0' : 'text-secondary-500'} border-primary-200 cursor-pointer rounded-[10px] border px-[28px] py-[8px] text-[16px] font-semibold text-nowrap sm:text-[20px]`}
+      className={`${isActive ? 'bg-primary-400 text-primary-0' : 'text-secondary-500'} border-primary-200 cursor-pointer rounded-[10px] border px-[18px] py-[8px] text-[16px] font-semibold text-nowrap sm:w-full sm:text-[16px]`}
     >
       {children}
     </button>

--- a/src/app/(afterlogin)/weather/page.tsx
+++ b/src/app/(afterlogin)/weather/page.tsx
@@ -14,77 +14,94 @@ import useGetLocationName from '@/app/_hooks/useGetLocationName';
 import WeeklyContainer from './WeeklyContainer';
 import { currentIndex } from './_constant/currentIndex';
 import { getWeatherInfo } from '@/app/_utils/getWeatherInfo';
+import spinner from '@/assets/lottie/spinner.json';
+import dynamic from 'next/dynamic';
+
+const Lottie = dynamic(() => import('lottie-react'), { ssr: false });
 
 export default function Weather() {
-  const { data: weatherData, isPending } = useGetWeatherQuery();
+  const {
+    data: weatherData,
+    isLoading,
+    geoLocationError,
+  } = useGetWeatherQuery();
   const { locationName } = useGetLocationName();
-
-  if (!weatherData || isPending) {
-    return;
-  }
-
-  const currentData = weatherData.current;
-  const hourlyData = weatherData.hourly;
-  const weeklyData = weatherData.daily;
 
   return (
     <div className='text-secondary-500 inline-flex h-full min-h-screen w-full flex-col bg-[#FAFAFA] sm:flex-row'>
       <Navigation />
-      <div className='h-full w-full min-w-[752px]'>
+      <div className='relative flex h-dvh w-full min-w-[752px] flex-col'>
         <div className='bg-primary-0 flex flex-col'>
           <BoardTitle title='날씨'></BoardTitle>
         </div>
-        <main className='flex w-dvw min-w-[375px] flex-col gap-x-[50px] gap-y-[23px] p-[32px] sm:w-full sm:flex-row'>
-          <div className='flex flex-col gap-[23px] sm:w-[60%]'>
-            <section className='flex flex-col gap-[15px]'>
-              <p className='text-[22px] font-semibold sm:text-[24px]'>현재</p>
-              <CurrentWeather
-                location={locationName}
-                currentTime={currentData.time}
-                temperature={`${currentData?.temperature}°`}
-                weatherInfo={getWeatherInfo(currentData.weathercode)}
+        {}
+        {isLoading || !weatherData ? (
+          <div className='absolute top-1/2 left-1/2 flex-1 -translate-1/2 text-center'>
+            {geoLocationError ? (
+              <div className='text-[18px] font-medium'>
+                날씨 정보를 불러올 수 없습니다. <br /> 위치 액세스를
+                허용해주세요
+              </div>
+            ) : (
+              <Lottie
+                animationData={spinner}
+                style={{ width: 100, height: 100 }}
               />
-              <HourlyContainer>
-                {hourlyData.map(
-                  ({ time, temperature, precipitation, weathercode }) => (
-                    <HourlyWeather
-                      key={time}
-                      time={format(time, 'ha')}
-                      temperature={`${temperature}°`}
-                      rainfall={`${precipitation}%`}
-                      weatherInfo={getWeatherInfo(weathercode)}
-                    />
-                  ),
-                )}
-              </HourlyContainer>
-            </section>
-            <section className='grid grid-cols-2 gap-[16px] sm:grid-cols-3 sm:gap-[30px]'>
-              {currentIndex.map(({ id, type, typeName, unit }) => (
-                <CurrentIndex
-                  key={id}
-                  type={typeName}
-                  value={currentData[type]}
-                  subValue={unit}
+            )}
+          </div>
+        ) : (
+          <main className='flex w-dvw min-w-[375px] flex-col gap-x-[50px] gap-y-[23px] p-[32px] sm:w-full sm:flex-row'>
+            <div className='flex flex-col gap-[23px] sm:w-[60%]'>
+              <section className='flex flex-col gap-[15px]'>
+                <p className='text-[22px] font-semibold sm:text-[24px]'>현재</p>
+                <CurrentWeather
+                  location={locationName}
+                  currentTime={weatherData.current.time}
+                  temperature={`${weatherData.current.temperature}°`}
+                  weatherInfo={getWeatherInfo(weatherData.current.weathercode)}
                 />
-              ))}
-            </section>
-          </div>
-          <div className='flex flex-col gap-[23px] sm:w-[40%]'>
-            <section className='flex flex-col gap-[15px]'>
-              <p className='text-[22px] font-semibold sm:text-[24px]'>
-                주간 날씨
-              </p>
-              <WeeklyContainer>
-                {weeklyData.map(data => (
-                  <WeeklyWeather key={data.date} data={data} />
+                <HourlyContainer>
+                  {weatherData.hourly.map(
+                    ({ time, temperature, precipitation, weathercode }) => (
+                      <HourlyWeather
+                        key={time}
+                        time={format(time, 'ha')}
+                        temperature={`${temperature}°`}
+                        rainfall={`${precipitation}%`}
+                        weatherInfo={getWeatherInfo(weathercode)}
+                      />
+                    ),
+                  )}
+                </HourlyContainer>
+              </section>
+              <section className='grid grid-cols-2 gap-[16px] sm:grid-cols-3 sm:gap-[30px]'>
+                {currentIndex.map(({ id, type, typeName, unit }) => (
+                  <CurrentIndex
+                    key={id}
+                    type={typeName}
+                    value={weatherData.current[type]}
+                    subValue={unit}
+                  />
                 ))}
-              </WeeklyContainer>
-            </section>
-            <section className=''>
-              <RecommendDress />
-            </section>
-          </div>
-        </main>
+              </section>
+            </div>
+            <div className='flex flex-col gap-[23px] sm:w-[40%]'>
+              <section className='flex flex-col gap-[15px]'>
+                <p className='text-[22px] font-semibold sm:text-[24px]'>
+                  주간 날씨
+                </p>
+                <WeeklyContainer>
+                  {weatherData.daily.map(data => (
+                    <WeeklyWeather key={data.date} data={data} />
+                  ))}
+                </WeeklyContainer>
+              </section>
+              <section className=''>
+                <RecommendDress />
+              </section>
+            </div>
+          </main>
+        )}
       </div>
     </div>
   );

--- a/src/app/(afterlogin)/weather/page.tsx
+++ b/src/app/(afterlogin)/weather/page.tsx
@@ -30,7 +30,7 @@ export default function Weather() {
   return (
     <div className='text-secondary-500 inline-flex h-full min-h-screen w-full flex-col bg-[#FAFAFA] sm:flex-row'>
       <Navigation />
-      <div className='relative flex h-dvh w-full min-w-[752px] flex-col'>
+      <div className='relative flex h-dvh w-full flex-col sm:min-w-[752px]'>
         <div className='bg-primary-0 flex flex-col'>
           <BoardTitle title='날씨'></BoardTitle>
         </div>
@@ -45,7 +45,7 @@ export default function Weather() {
             ) : (
               <Lottie
                 animationData={spinner}
-                style={{ width: 100, height: 100 }}
+                style={{ width: 50, height: 50 }}
               />
             )}
           </div>

--- a/src/app/_components/common/NormalTextarea.tsx
+++ b/src/app/_components/common/NormalTextarea.tsx
@@ -33,7 +33,7 @@ function NormalTextarea({
         {...rest}
         ref={textareaRef}
         value={value}
-        className='scroll-none flex-1 resize-none outline-none'
+        className='scroll-none w-full flex-1 resize-none outline-none'
       />
     </div>
   );

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -217,7 +217,7 @@ function TaskModal({ mode, isOpen, setIsOpen, task, type }: TaskModalProps) {
 
   return (
     isOpen && (
-      <div className='fixed inset-0 z-50 flex h-dvh w-dvw items-center justify-center bg-[rgba(84,87,122,0.3)]'>
+      <div className='fixed inset-0 z-50 flex min-h-dvh w-dvw items-center justify-center bg-[rgba(84,87,122,0.3)]'>
         <div className='bg-primary-0 w-[80%] min-w-[335px] rounded-[10px] px-[30px] py-[20px] shadow-[0_0_30px_0_rgba(84,87,122,0.7)] *:w-full sm:w-[708px] sm:px-[40px] sm:py-[30px]'>
           <div className='mb-[30px] flex justify-between'>
             <p className='text-[24px] font-semibold sm:text-3xl'>

--- a/src/app/_hooks/useGetWeatherQuery.ts
+++ b/src/app/_hooks/useGetWeatherQuery.ts
@@ -5,13 +5,17 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { WeatherResponse } from '../_types/weather';
 
 const useGetWeatherQuery = () => {
-  const { location, error } = useCurrentLocation();
+  const { location, error: geoLocationError } = useCurrentLocation();
 
-  return useQuery<AxiosResponse<WeatherResponse>, AxiosError, WeatherResponse>({
+  const { data, isLoading, isError } = useQuery<
+    AxiosResponse<WeatherResponse>,
+    AxiosError,
+    WeatherResponse
+  >({
     queryKey: ['weather', location],
     queryFn: () => {
       if (!location) {
-        throw new Error(error ?? '위치 정보를 가져올 수 없습니다.');
+        throw new Error('위치 정보를 가져올 수 없습니다.');
       }
 
       return getWeather(location);
@@ -19,6 +23,8 @@ const useGetWeatherQuery = () => {
     enabled: !!location,
     select: data => data.data,
   });
+
+  return { data, isLoading, isError, geoLocationError };
 };
 
 export default useGetWeatherQuery;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,10 @@ import useGetLocationName from './_hooks/useGetLocationName';
 import useGetWeatherQuery from './_hooks/useGetWeatherQuery';
 import { getWeatherInfo } from './_utils/getWeatherInfo';
 import DashBoardTopNews from './(afterlogin)/news/DashBoardTopNews';
+import spinner from '@/assets/lottie/spinner.json';
+import dynamic from 'next/dynamic';
+
+const Lottie = dynamic(() => import('lottie-react'), { ssr: false });
 
 export default function Dashboard() {
   const [isOpen, setIsOpen] = useState(false);
@@ -23,7 +27,11 @@ export default function Dashboard() {
   const router = useRouter();
   const { data: taskList = [] } = useGetTaskQuery('day');
   const { locationName } = useGetLocationName();
-  const { data: weatherData } = useGetWeatherQuery();
+  const {
+    data: weatherData,
+    geoLocationError,
+    isLoading,
+  } = useGetWeatherQuery();
 
   const getCurrentTime = () => {
     const currentDate = new Date();
@@ -70,10 +78,6 @@ export default function Dashboard() {
   useEffect(() => {
     setFinishedTaskCount(taskList.filter(task => task.is_completed).length);
   }, [taskList]);
-
-  if (!weatherData) {
-    return;
-  }
 
   return (
     <div className='text-secondary-500 flex h-full min-h-screen flex-col sm:min-w-[1440px] sm:flex-row'>
@@ -125,11 +129,27 @@ export default function Dashboard() {
           <div className='text-secondary-500 hidden text-[24px] font-medium sm:block sm:text-[40px]'>
             {currentTime}
           </div>
-          <CurrentWeather
-            location={locationName}
-            temperature={`${weatherData.current?.temperature}°`}
-            weatherInfo={getWeatherInfo(weatherData.current.weathercode)}
-          />
+          {!weatherData || isLoading ? (
+            <div className='border-primary-200 bg-primary-0 flex flex-col items-center justify-center gap-[10px] rounded-2xl border px-[30px] py-[26px]'>
+              {geoLocationError ? (
+                <div>
+                  날씨 정보를 불러올 수 없습니다.
+                  <br /> 위치 액세스를 허용해주세요
+                </div>
+              ) : (
+                <Lottie
+                  animationData={spinner}
+                  style={{ width: 50, height: 50 }}
+                />
+              )}
+            </div>
+          ) : (
+            <CurrentWeather
+              location={locationName}
+              temperature={`${weatherData.current?.temperature}°`}
+              weatherInfo={getWeatherInfo(weatherData.current.weathercode)}
+            />
+          )}
           <DashBoardTopNews />
         </div>
       </div>


### PR DESCRIPTION
## 💡 작업 내용

- [x] 날씨 정보 로딩 스피너 추가
- [x] 위치 액세스 비허용 시 피드백 UI 구현

## 💡 자세한 설명

### 1️⃣ 날씨 정보 로딩 스피너 및 위치 엑세스 피드백 UI 추가 
대시보드와 날씨 페이지에 날씨 정보를 불러오는 동안 빈 페이지가 나오고 있었습니다. 
UX를 개선하기 위해 로딩 스피너를 추가하였습니다. 
위치 엑세스가 허용되지 않았을 경우에는 허용해달라는 문구가 나타나도록 구현했습니다. 

#### 위치 엑세스 비허용 되었을 때
![image](https://github.com/user-attachments/assets/9cc70be0-8b05-481f-bf97-f55749f3e0a0)

#### 로딩 중일 때
![2025-04-30 18;08;13](https://github.com/user-attachments/assets/f74085bf-93d1-46b0-afcb-31ea81f0ba59)

v1.1.0 배포 후 화면 줄였을 때 나타났단 reverseGeocode를 찾을 수 없다는 에러는 지금 다시 시도해보니 뜨지 않아서 원인을 찾지 못했습니다..! 


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
