### PR TITLE
feat: 뉴스 카테고리 설정 기능 구현

### DIFF
--- a/src/app/(afterlogin)/news/CategoryButton.tsx
+++ b/src/app/(afterlogin)/news/CategoryButton.tsx
@@ -8,7 +8,7 @@ function CategoryButton({ children, isActive, onClick }: CategoryButtonProps) {
   return (
     <button
       onClick={onClick}
-      className={`${isActive ? 'bg-primary-400 text-primary-0' : 'text-secondary-500'} border-primary-200 cursor-pointer rounded-[10px] border px-[28px] py-[8px] text-[16px] font-semibold text-nowrap sm:text-[20px]`}
+      className={`${isActive ? 'bg-primary-400 text-primary-0' : 'text-secondary-500'} border-primary-200 cursor-pointer rounded-[10px] border px-[28px] py-[8px] text-[14px] font-semibold text-nowrap sm:text-[16px]`}
     >
       {children}
     </button>

--- a/src/app/(afterlogin)/news/NewsCategory.tsx
+++ b/src/app/(afterlogin)/news/NewsCategory.tsx
@@ -3,6 +3,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import CategoryButton from './CategoryButton';
 import { useEffect, useState } from 'react';
 import { NewsCategoryType } from '@/app/_types/news';
+import { useNewsCategoryStore } from '@/app/store/newsCategoryStore';
 
 type CategoriesType = {
   id: number;
@@ -78,6 +79,11 @@ function NewsCategory({ onSelectedCategory }: NewsCategoryProps) {
   const router = useRouter();
   const [selectedCategory, setSelectedCategory] =
     useState<NewsCategoryType>('top');
+  const { newsCategories } = useNewsCategoryStore();
+
+  const formattedCategories = categories.filter(item =>
+    newsCategories.includes(item.category),
+  );
 
   const handleClick = (category: NewsCategoryType) => {
     const newParams = new URLSearchParams(searchParam?.toString());
@@ -109,7 +115,7 @@ function NewsCategory({ onSelectedCategory }: NewsCategoryProps) {
 
   return (
     <>
-      {categories.map(({ id, name, category }) => (
+      {formattedCategories.map(({ id, name, category }) => (
         <CategoryButton
           key={id}
           onClick={() => handleClick(category)}

--- a/src/app/(afterlogin)/news/page.tsx
+++ b/src/app/(afterlogin)/news/page.tsx
@@ -23,7 +23,7 @@ export default function News() {
           <BoardTitle title='뉴스' />
         </div>
         <div className='flex w-full flex-1 flex-col gap-[20px] bg-[#F5F5F7] px-[32px] py-[20px]'>
-          <section className='scrollbar-hidden flex gap-[10px] overflow-x-scroll sm:justify-between'>
+          <section className='scrollbar-hidden flex gap-[10px] overflow-x-scroll sm:justify-start'>
             <Suspense fallback={<div>loading...</div>}>
               <NewsCategory
                 selectedCategory={category}

--- a/src/app/(afterlogin)/setting/EtcSetting.tsx
+++ b/src/app/(afterlogin)/setting/EtcSetting.tsx
@@ -14,6 +14,7 @@ function EtcSetting() {
 
   const saveSetting = () => {
     setCategories(selectedCategory);
+    alert('저장되었습니다.');
   };
 
   return (

--- a/src/app/(afterlogin)/setting/EtcSetting.tsx
+++ b/src/app/(afterlogin)/setting/EtcSetting.tsx
@@ -3,13 +3,27 @@ import NewsSetting from './_settings/NewsSetting';
 import WeatherLocationSetting from './_settings/WeatherLocationSetting';
 import RouteSetting from './_settings/RouteSetting';
 import SettingContainer from './_component/SettingContainer';
+import { useNewsCategoryStore } from '@/app/store/newsCategoryStore';
+import { useState } from 'react';
+import { NewsCategoryType } from '@/app/_types/news';
 
 function EtcSetting() {
+  const { newsCategories, setCategories } = useNewsCategoryStore();
+  const [selectedCategory, setSelectedCategory] =
+    useState<NewsCategoryType[]>(newsCategories);
+
+  const saveSetting = () => {
+    setCategories(selectedCategory);
+  };
+
   return (
     <div className='flex h-full min-h-[400px] flex-col'>
       <div className='mb-[108px] flex flex-1 flex-col gap-[32px]'>
         <SettingContainer title='뉴스 Topic'>
-          <NewsSetting />
+          <NewsSetting
+            selectedCategory={selectedCategory}
+            setSelectedCategory={setSelectedCategory}
+          />
         </SettingContainer>
         <SettingContainer title='날씨 표시 위치'>
           <WeatherLocationSetting />
@@ -19,7 +33,9 @@ function EtcSetting() {
         </SettingContainer>
       </div>
 
-      <SubmitButton className='sm:max-w-[216px]'>저장</SubmitButton>
+      <SubmitButton className='sm:max-w-[216px]' onClick={saveSetting}>
+        저장
+      </SubmitButton>
     </div>
   );
 }

--- a/src/app/(afterlogin)/setting/_settings/NewsSetting.tsx
+++ b/src/app/(afterlogin)/setting/_settings/NewsSetting.tsx
@@ -1,11 +1,18 @@
-import { useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import CategoryButton from '../../news/CategoryButton';
 import { categories } from '../../news/NewsCategory';
+import { NewsCategoryType } from '@/app/_types/news';
 
-function NewsSetting() {
-  const [selectedCategory, setSelectedCategory] = useState<string[]>([]);
+interface NewsSettingProps {
+  selectedCategory: NewsCategoryType[];
+  setSelectedCategory: Dispatch<SetStateAction<NewsCategoryType[]>>;
+}
 
-  const handleToggle = (category: string) => {
+function NewsSetting({
+  selectedCategory,
+  setSelectedCategory,
+}: NewsSettingProps) {
+  const handleToggle = (category: NewsCategoryType) => {
     if (selectedCategory.includes(category)) {
       return setSelectedCategory(prev =>
         prev.filter(selected => selected !== category),
@@ -13,6 +20,7 @@ function NewsSetting() {
     }
     return setSelectedCategory(prev => [...prev, category]);
   };
+
   return (
     <div className='flex flex-wrap gap-[10px] *:text-[12px]!'>
       {categories.map(({ id, name, category }) => (

--- a/src/app/(afterlogin)/setting/_settings/NewsSetting.tsx
+++ b/src/app/(afterlogin)/setting/_settings/NewsSetting.tsx
@@ -23,15 +23,19 @@ function NewsSetting({
 
   return (
     <div className='flex flex-wrap gap-[10px] *:text-[12px]!'>
-      {categories.map(({ id, name, category }) => (
-        <CategoryButton
-          key={id}
-          onClick={() => handleToggle(category)}
-          isActive={selectedCategory.includes(category)}
-        >
-          {name}
-        </CategoryButton>
-      ))}
+      {categories.map(({ id, name, category }) => {
+        if (category === 'top') return;
+
+        return (
+          <CategoryButton
+            key={id}
+            onClick={() => handleToggle(category)}
+            isActive={selectedCategory.includes(category)}
+          >
+            {name}
+          </CategoryButton>
+        );
+      })}
     </div>
   );
 }

--- a/src/app/store/newsCategoryStore.ts
+++ b/src/app/store/newsCategoryStore.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { NewsCategoryType } from '../_types/news';
+
+interface NewsCategoryState {
+  newsCategories: NewsCategoryType[];
+  setCategories: (newsCategories: NewsCategoryType[]) => void;
+}
+
+const initialCategories: NewsCategoryType[] = [
+  'top',
+  'sports',
+  'technology',
+  'business',
+  'science',
+  'entertainment',
+  'health',
+  'world',
+  'politics',
+  'environment',
+  'food',
+];
+
+export const useNewsCategoryStore = create<NewsCategoryState>()(
+  persist(
+    set => ({
+      newsCategories: initialCategories,
+      setCategories: newsCategories => set({ newsCategories }),
+    }),
+    {
+      name: 'newsCategory',
+    },
+  ),
+);


### PR DESCRIPTION
## 💡 작업 내용

- [x] 뉴스 카테고리 설정 기능 구현

## 💡 자세한 설명

### 1️⃣ 뉴스 카테고리 설정 기능
새로고침이 되어도 설정된 카테고리가 적용될 수 있도록 로컬스토리지를 사용해 구현했습니다. (zustand의 persist 활용)

```ts
export const useNewsCategoryStore = create<NewsCategoryState>()(
  persist(
    set => ({
      newsCategories: initialCategories,
      setCategories: newsCategories => set({ newsCategories }),
    }),
    {
      name: 'newsCategory',
    },
  ),
);
```

#### 스크린샷
![2025-04-30 19;42;57](https://github.com/user-attachments/assets/29aaccec-0376-4508-96d0-a2d2c51c8c7a)


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
