### PR TITLE
fix: 일정 관리 버그 해결

### DIFF
--- a/src/app/(afterlogin)/news/Articles.tsx
+++ b/src/app/(afterlogin)/news/Articles.tsx
@@ -16,7 +16,7 @@ function Articles({ category }: ArticlesProps) {
   if (isLoading) {
     return (
       <div className='flex h-full items-center justify-center'>
-        <Lottie animationData={spinner} style={{ width: 50, height: 50 }} />
+        <Lottie animationData={spinner} style={{ width: 100, height: 100 }} />
       </div>
     );
   }

--- a/src/app/_components/tasks/TaskListItem.tsx
+++ b/src/app/_components/tasks/TaskListItem.tsx
@@ -22,8 +22,11 @@ function TaskListItem({ task }: TaskProps) {
   const editCheck = () => {
     const updatedTask = {
       ...task,
+      start_time: new Date(task.start_time).toISOString(),
+      end_time: new Date(task.end_time).toISOString(),
       is_completed: !task.is_completed,
     };
+
     editTaskMutate(updatedTask);
   };
 

--- a/src/app/_components/tasks/TaskModal.tsx
+++ b/src/app/_components/tasks/TaskModal.tsx
@@ -24,7 +24,6 @@ import isEqual from 'lodash/isEqual';
 import useAddTaskMutation from '@/app/_hooks/useAddTaskMutation';
 import useEditTaskMutation from '@/app/_hooks/useEditTaskMutation';
 import useDeleteTaskMutation from '@/app/_hooks/useDeleteTaskMutation';
-import { toZonedTime } from 'date-fns-tz';
 import { GeoSearchResult } from '@/app/_types/location';
 
 export type ModalMode = 'add' | 'edit' | 'detail';
@@ -77,10 +76,8 @@ const initialTask = {
 const normalizeTaskDate = (task: TaskPayload | TaskCalendar): TaskCalendar => {
   if (task.start_time instanceof Date) return task as TaskCalendar;
 
-  const start_time = new Date(toZonedTime(task.start_time, 'UTC'));
-  const end_time = task.end_time
-    ? new Date(toZonedTime(task.end_time, 'UTC'))
-    : start_time;
+  const start_time = new Date(task.start_time);
+  const end_time = task.end_time ? new Date(task.end_time) : start_time;
 
   return { ...task, start_time, end_time };
 };

--- a/src/app/_utils/dateTimeUtil.ts
+++ b/src/app/_utils/dateTimeUtil.ts
@@ -1,17 +1,13 @@
 import {
+  format,
   secondsToHours,
   secondsToMinutes,
   setHours,
   setMinutes,
 } from 'date-fns';
 
-
 export const formatTime = (date: string | Date) => {
-  return new Intl.DateTimeFormat('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  }).format(new Date(date));
+  return format(date, 'h:mm a');
 };
 
 export const parseTimeString = (time: string): [number, number] => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,7 +59,7 @@ export default function Dashboard() {
     }, 1000);
 
     return () => clearInterval(interval);
-  }, []);
+  }, [router]);
 
   useEffect(() => {
     const todayDate = new Date();


### PR DESCRIPTION
## 💡 작업 내용

- [x] 일정 등록, 수정 시 UTC ISO 8601 형식의 문자열로 저장(UTC 기준)
- [x] 일정 조회 시 타임존 변환 로직 제거 (백엔드에서 KST 기준으로 반환)

## 💡 자세한 설명

### 문제 
1. 일정 일간 페이지의 시간이 한국 기준 등록한 시간과 일치하지 않았음. 
2. 일정 수정 시 데이터가 DB엔 남아있지만 페이지에 뜨지 않는 문제

### 원인 
#35 에서 일정 post 요청 시 UTC로 등록하도록 수정했었는데 일간 페이지에서 일부 수정처리가 되지 않았던 것으로 추측합니다. 
또한, 일정 수정(patch 요청)할 때는 고려하지 못하였습니다. 
등록과 수정할 때의 형식이 다른 상태, 조회할 때 등록에만 맞춰 수정된 코드로 인해 수정한 후에는 일정 제대로 보이지 않았던 것 같습니다. 

### 해결 
백엔드에서 일정 조회 API로 UTC -> KST 로 변환 후 반환하도록 수정되었습니다. (Z 문자열 제거된 후 반환)
프론트에서는 일정 등록 및 수정 시 UTC (ISO 8601 형식) 으로 요청 보내며 조회 시에는 서버에서 받은 KST 문자열 그대로 사용하도록 수정했습니다. 

로컬에서 테스트했을 땐 잘 동작하는 것을 확인했습니다!

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
