### PR TITLE
fix: 길찾기 부분의 출발시각/도착시각 제거

### DIFF
--- a/src/app/(afterlogin)/calendar/_components/RouteInfo.tsx
+++ b/src/app/(afterlogin)/calendar/_components/RouteInfo.tsx
@@ -1,5 +1,4 @@
 import { TaskWithDuration } from '@/app/_types';
-import { formatTime } from '@/app/_utils/dateTimeUtil';
 
 interface RouteInfoProps {
   label: string;
@@ -17,11 +16,6 @@ function RouteInfo({ label, task }: RouteInfoProps) {
           {label === '출발' ? task.from_place_name : task.place_name}
         </span>
       </div>
-      <span className='text-[14px] font-medium whitespace-nowrap sm:text-[16px]'>
-        {label === '출발'
-          ? formatTime(task.start_time)
-          : formatTime(task.end_time)}
-      </span>
     </div>
   );
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 길찾기 부분의 출발시각 / 도착시각 제거

## 💡 자세한 설명

### 1️⃣ 길찾기 부분의 시각 제거
길찾기 부분에 출력되는 출발시각과 도착시각이 일정의 시작/완료 시간과 같기 때문에 해당 부분을 제거햐였습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
