### PR TITLE
fix: 배경 높이 고정되어 나오는 문제 수정

### DIFF
--- a/src/app/(afterlogin)/news/page.tsx
+++ b/src/app/(afterlogin)/news/page.tsx
@@ -16,7 +16,7 @@ export default function News() {
   };
 
   return (
-    <div className='text-secondary-500 flex h-dvh min-h-screen flex-col sm:min-w-[1440px] sm:flex-row'>
+    <div className='text-secondary-500 flex min-h-dvh flex-col sm:min-w-[1440px] sm:flex-row'>
       <Navigation />
       <div className='flex h-full w-dvw min-w-[375px] flex-col sm:min-w-[752px]'>
         <div className='bg-primary-0 flex flex-col'>

--- a/src/app/(afterlogin)/weather/page.tsx
+++ b/src/app/(afterlogin)/weather/page.tsx
@@ -30,7 +30,7 @@ export default function Weather() {
   return (
     <div className='text-secondary-500 inline-flex h-full min-h-screen w-full flex-col bg-[#FAFAFA] sm:flex-row'>
       <Navigation />
-      <div className='relative flex h-dvh w-full flex-col sm:min-w-[752px]'>
+      <div className='relative flex min-h-dvh w-full flex-col sm:min-w-[752px]'>
         <div className='bg-primary-0 flex flex-col'>
           <BoardTitle title='날씨'></BoardTitle>
         </div>


### PR DESCRIPTION
## 💡 작업 내용

- [x] 배경 높이 고정 문제 수정

## 💡 자세한 설명

### 1️⃣ 배경 높이 고정 문제 수정
높이가 `h-dvh`로 설정되어 있던 날씨 페이지에서 다음과 같이 아랫 부분이 빠져나오는 문제가 발생하여 수정하였습니다.

> 수정사항 : `h-dvh` 를 `min-h-dvh`로 변경

![image](https://github.com/user-attachments/assets/a960d61a-3194-4a5f-a32e-9ae949a28446)
확인해보니 뉴스 페이지도 같은 현상이 발생하여 함께 수정해 두었습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
